### PR TITLE
Encapsulate shader attribute/uniform variable locations

### DIFF
--- a/src/shaders/flat/shader.ts
+++ b/src/shaders/flat/shader.ts
@@ -8,9 +8,9 @@ export class FlatShader extends Shader {
     constructor (gl: WebGL2RenderingContext) {
       super(gl, vertexSrc, fragmentSrc)
 
-      this.location.setAttribute('vertexPosition');
-      this.location.setUniform('modelViewProjectionMatrix');
-      this.location.setUniform('color');
+      this.locations.setAttribute('vertexPosition');
+      this.locations.setUniform('modelViewProjectionMatrix');
+      this.locations.setUniform('color');
     }
 
     render (r: Renderable) {
@@ -23,16 +23,16 @@ export class FlatShader extends Shader {
       this.gl.clear(this.gl.COLOR_BUFFER_BIT | this.gl.DEPTH_BUFFER_BIT)
 
       this.gl.bindBuffer(this.gl.ARRAY_BUFFER, r.buffer.vertices)
-      const vertexPosition = this.location.getAttribute('vertexPosition');
+      const vertexPosition = this.locations.getAttribute('vertexPosition');
       this.gl.vertexAttribPointer(vertexPosition, 3, this.gl.FLOAT, false, 0, 0)
       this.gl.enableVertexAttribArray(vertexPosition)
 
-      this.gl.uniformMatrix4fv(this.location.getUniform('modelViewProjectionMatrix'), false, r.matrix.modelViewProjection)
+      this.gl.uniformMatrix4fv(this.locations.getUniform('modelViewProjectionMatrix'), false, r.matrix.modelViewProjection)
 
       let offset = 0
       this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, r.buffer.faces)
       r.object.faces.forEach((f) => {
-        this.gl.uniform3fv(this.location.getUniform('color'), f.material.diffuse)
+        this.gl.uniform3fv(this.locations.getUniform('color'), f.material.diffuse)
 
         this.gl.drawElements(this.gl.TRIANGLES, f.vertex_indices.length, this.gl.UNSIGNED_SHORT, offset)
         // Offset must be a multiple of 2 since an unsigned short is 2 bytes.

--- a/src/shaders/shader.ts
+++ b/src/shaders/shader.ts
@@ -1,10 +1,10 @@
 import { Renderable } from '../renderables/renderable'
-import { ShaderLocation } from './shader_location';
+import { ShaderLocations } from './shader_locations';
 
 export abstract class Shader {
     readonly gl: WebGL2RenderingContext;
     readonly program: WebGLProgram;
-    readonly location: ShaderLocation;
+    readonly locations: ShaderLocations;
 
     constructor (gl: WebGL2RenderingContext, vertexSrc: string, fragmentSrc: string) {
       const program = gl.createProgram()
@@ -27,7 +27,7 @@ export abstract class Shader {
 
       this.gl = gl
       this.program = program
-      this.location = new ShaderLocation(gl, program);
+      this.locations = new ShaderLocations(gl, program);
     }
 
     private compileShader (gl: WebGLRenderingContext, type: number, src: string): WebGLShader {

--- a/src/shaders/shader_locations.ts
+++ b/src/shaders/shader_locations.ts
@@ -1,4 +1,4 @@
-export class ShaderLocation {
+export class ShaderLocations {
 	private gl: WebGL2RenderingContext;
 	private program: WebGLProgram;
 
@@ -17,8 +17,8 @@ export class ShaderLocation {
 	}
 
 	setUniform(name: string) {
-		const location = this.gl.getUniformLocation(this.program, name);
-		this.uniforms.set(name, location);
+		const locations = this.gl.getUniformLocation(this.program, name);
+		this.uniforms.set(name, locations);
 	}
 
 	getAttribute(name: string): GLint {
@@ -26,7 +26,7 @@ export class ShaderLocation {
 	}
 
 	setAttribute(name: string) {
-		const location = this.gl.getAttribLocation(this.program, name);
-		this.attributes.set(name, location);
+		const locations = this.gl.getAttribLocation(this.program, name);
+		this.attributes.set(name, locations);
 	}
 }

--- a/src/shaders/texture/shader.ts
+++ b/src/shaders/texture/shader.ts
@@ -19,8 +19,8 @@ export class TextureShader extends Shader {
     constructor(gl: WebGL2RenderingContext) {
         super(gl, vertexSrc, fragmentSrc);
 
-        this.location.setAttribute('vertexPosition');
-        this.location.setUniform('textureImage');
+        this.locations.setAttribute('vertexPosition');
+        this.locations.setUniform('textureImage');
 
         this.verticesBuffer = gl.createBuffer();
         gl.bindBuffer(this.gl.ARRAY_BUFFER, this.verticesBuffer);
@@ -31,7 +31,7 @@ export class TextureShader extends Shader {
         this.gl.useProgram(this.program);
 
         this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.verticesBuffer);
-        const vertexPosition = this.location.getAttribute('vertexPosition');
+        const vertexPosition = this.locations.getAttribute('vertexPosition');
         this.gl.vertexAttribPointer(vertexPosition, 2, this.gl.FLOAT, false, 0, 0);
         this.gl.enableVertexAttribArray(vertexPosition);
 
@@ -41,7 +41,7 @@ export class TextureShader extends Shader {
         this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_WRAP_T, this.gl.CLAMP_TO_EDGE);
         this.gl.texParameteri(this.gl.TEXTURE_2D, this.gl.TEXTURE_MIN_FILTER, this.gl.LINEAR);
 
-        this.gl.uniform1i(this.location.getUniform('textureImage'), 0);
+        this.gl.uniform1i(this.locations.getUniform('textureImage'), 0);
         this.gl.drawArrays(this.gl.TRIANGLES, 0, TextureShader.vertices.length);
     }
 }

--- a/src/shaders/transparent/shader.ts
+++ b/src/shaders/transparent/shader.ts
@@ -24,11 +24,11 @@ export class TransparentShader extends Shader {
         this.colorTextures = this.createColorTextures(NUM_PASSES);
         this.colorBuffer = this.createColorBuffer();
 
-        this.location.setAttribute('vertexPosition');
-        this.location.setUniform('modelViewProjectionMatrix');
-        this.location.setUniform('color');
-        this.location.setUniform('depthTexture');
-        this.location.setUniform('shouldDepthPeel');
+        this.locations.setAttribute('vertexPosition');
+        this.locations.setUniform('modelViewProjectionMatrix');
+        this.locations.setUniform('color');
+        this.locations.setUniform('depthTexture');
+        this.locations.setUniform('shouldDepthPeel');
     }
 
     render(r: Renderable) {
@@ -38,16 +38,16 @@ export class TransparentShader extends Shader {
             this.depthPeel(i);
 
             this.gl.bindBuffer(this.gl.ARRAY_BUFFER, r.buffer.vertices);
-            const vertexPosition = this.location.getAttribute('vertexPosition');
+            const vertexPosition = this.locations.getAttribute('vertexPosition');
             this.gl.vertexAttribPointer(vertexPosition, 3, this.gl.FLOAT, false, 0, 0);
             this.gl.enableVertexAttribArray(vertexPosition)
 
-            this.gl.uniformMatrix4fv(this.location.getUniform('modelViewProjectionMatrix'), false, r.matrix.modelViewProjection);
+            this.gl.uniformMatrix4fv(this.locations.getUniform('modelViewProjectionMatrix'), false, r.matrix.modelViewProjection);
 
             let offset = 0;
             this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, r.buffer.faces);
             r.object.faces.forEach((f) => {
-                this.gl.uniform3fv(this.location.getUniform('color'), f.material.diffuse);
+                this.gl.uniform3fv(this.locations.getUniform('color'), f.material.diffuse);
 
                 this.gl.drawElements(this.gl.TRIANGLES, f.vertex_indices.length, this.gl.UNSIGNED_SHORT, offset);
                 // Offset must be a multiple of 2 since an unsigned short is 2 bytes.
@@ -85,10 +85,10 @@ export class TransparentShader extends Shader {
 
         this.gl.activeTexture(this.gl.TEXTURE0 + readIndex);
         this.gl.bindTexture(this.gl.TEXTURE_2D, this.depthTextures[readIndex]);
-        this.gl.uniform1i(this.location.getUniform('depthTexture'), readIndex);
+        this.gl.uniform1i(this.locations.getUniform('depthTexture'), readIndex);
 
         // No depth peeling on 0th iteration.
-        this.gl.uniform1i(this.location.getUniform('shouldDepthPeel'), i);
+        this.gl.uniform1i(this.locations.getUniform('shouldDepthPeel'), i);
 
         this.gl.bindFramebuffer(this.gl.DRAW_FRAMEBUFFER, this.framebuffer);
         this.gl.activeTexture(this.gl.TEXTURE0 + writeIndex);


### PR DESCRIPTION
Introduce the `ShaderLocations` class, which encapsulates the locations of attribute and uniform variables from shader programs.