### PR TITLE
Fix Blinn-Phong shader

### DIFF
--- a/src/shaders/blinn_phong/fragment.glsl
+++ b/src/shaders/blinn_phong/fragment.glsl
@@ -34,7 +34,8 @@ void main(void) {
     for (int i = 0; i < NUM_LIGHTS; i++) {
         Light light = lights[i];
         vec3 lightDirection = normalize(light.position - position);
-        vec3 lightColor = light.color * light.power / length(lightDirection);
+        float lightDistance = length(light.position - position);
+        vec3 lightColor = light.color * light.power / (lightDistance * lightDistance);
 
         float lambertian = max(dot(lightDirection, fragNormal), 0.0);
         float specular = 0.0;

--- a/src/shaders/blinn_phong/shader.ts
+++ b/src/shaders/blinn_phong/shader.ts
@@ -60,7 +60,7 @@ export class BlinnPhongShader extends Shader {
             let offset = 0
             this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, r.buffer.faces);
             r.object.faces.forEach((f) => {
-                this.gl.uniform3fv(this.locations.getUniform('material.ambient'), f.material.diffuse);
+                this.gl.uniform3fv(this.locations.getUniform('material.ambient'), f.material.ambient);
                 this.gl.uniform3fv(this.locations.getUniform('material.diffuse'), f.material.diffuse);
                 this.gl.uniform3fv(this.locations.getUniform('material.specular'), f.material.specular);
                 this.gl.uniform1f(this.locations.getUniform('material.specularExponent'), f.material.specular_exponent);


### PR DESCRIPTION
- Correctly calculate light intensity (don't use the length of a normalized vector because that's always 1).
- Pass the correct material value for ambient color to the fragment shader.