### PR TITLE
Crepuscular rays

### DIFF
--- a/src/gl.ts
+++ b/src/gl.ts
@@ -18,7 +18,7 @@ class WebGL2 {
     gl: WebGL2RenderingContext,
     n: number,
     width?: number,
-    height?: number,
+    height?: number
   ): Array<WebGLTexture> {
     return WebGL2.createTextures(
       gl,
@@ -28,7 +28,7 @@ class WebGL2 {
       gl.UNSIGNED_BYTE,
       gl.LINEAR,
       width,
-      height,
+      height
     );
   }
 
@@ -54,7 +54,7 @@ class WebGL2 {
     type: number,
     filter: number,
     width?: number,
-    height?: number,
+    height?: number
   ): Array<WebGLTexture> {
     const textures = new Array<WebGLTexture>();
 

--- a/src/gl.ts
+++ b/src/gl.ts
@@ -16,7 +16,9 @@ class WebGL2 {
 
   static createColorTextures(
     gl: WebGL2RenderingContext,
-    n: number
+    n: number,
+    width?: number,
+    height?: number,
   ): Array<WebGLTexture> {
     return WebGL2.createTextures(
       gl,
@@ -24,7 +26,9 @@ class WebGL2 {
       gl.RGBA,
       gl.RGBA,
       gl.UNSIGNED_BYTE,
-      gl.LINEAR
+      gl.LINEAR,
+      width,
+      height,
     );
   }
 
@@ -48,7 +52,9 @@ class WebGL2 {
     format: number,
     attachment: number,
     type: number,
-    filter: number
+    filter: number,
+    width?: number,
+    height?: number,
   ): Array<WebGLTexture> {
     const textures = new Array<WebGLTexture>();
 
@@ -63,8 +69,8 @@ class WebGL2 {
         gl.TEXTURE_2D,
         0,
         format,
-        gl.drawingBufferWidth,
-        gl.drawingBufferHeight,
+        width ?? gl.drawingBufferWidth,
+        height ?? gl.drawingBufferHeight,
         0,
         attachment,
         type,

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,10 +2,11 @@
 import $ from "jquery";
 import WebGL2 from "./gl";
 import { Teapot } from "./renderables/teapot";
-// import { BlinnPhongShader } from "./shaders/blinn_phong/shader";
+import { CrepuscularRay } from "./shaders/crepuscular_ray/shader"
 import { TransparentShader } from "./shaders/transparent/shader";
 import { FXAA } from "./shaders/fxaa/shader";
 import { vec3 } from "gl-matrix";
+import Matrix from "./matrix";
 
 $(() => {
   const $canvas: JQuery<HTMLCanvasElement> = $("canvas");
@@ -44,47 +45,45 @@ $(() => {
       0
     );
 
-    /*
-    const lights = [
-      {
-        position: vec3.fromValues(-10, 10, -10),
-        color: vec3.fromValues(1, 1, 1),
-        power: 40,
-      },
-      {
-        position: vec3.fromValues(10, 10, -10),
-        color: vec3.fromValues(1, 1, 1),
-        power: 40,
-      },
-    ];
-    */
+    const light = {
+      position: vec3.fromValues(0, 10, -10),
+      color: vec3.fromValues(1, 1, 1),
+      power: 40,
+      matrix: new Matrix(gl),
+    }
 
-    // const blinnPhongShader = new BlinnPhongShader(gl, lights);
     const transparentShader = new TransparentShader(gl, {
       opaqueDepthTexture: depthTexture,
       fresnelColor: vec3.fromValues(1, 1, 1),
       fresnelHueShift: -20,
       fresnelExponent: 3.5,
     });
-    const fxaa = new FXAA(gl);
+    const crepuscularRay = new CrepuscularRay(gl, {
+      colorTexture,
+      light,
+      samples: 50,
+      density: 0.35,
+      weight: 5,
+      decay: 0.99,
+      exposure: 0.0035,
+    });
+   const fxaa = new FXAA(gl);
 
     const path = "https://gist.githubusercontent.com/tinnywang/58bda00c65fd7b14d0d15ea1c7a022db/raw/e6147607586052300501fa6be58fc80c51ac6d15/teapot.json";
 
     $.get(path, (data: string) => {
-      const teapot = JSON.parse(data)[0];
+      const teapot = new Teapot(gl, JSON.parse(data)[0]);
 
       const render = (_: DOMHighResTimeStamp) => {
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
-        // blinnPhongShader.render(framebuffer, new Teapot(gl, teapot));
-        transparentShader.render(framebuffer, new Teapot(gl, teapot));
+        transparentShader.render(framebuffer, teapot);
+        crepuscularRay.render(framebuffer, teapot);
 
         gl.bindFramebuffer(gl.READ_FRAMEBUFFER, framebuffer);
         gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);
-
         gl.disable(gl.BLEND);
 
-        // Post-processing effects.
         fxaa.render(colorTexture);
 
         gl.flush();

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,12 +1,12 @@
 // import { vec3 } from "gl-matrix";
 import $ from "jquery";
+import { vec3 } from "gl-matrix";
 import WebGL2 from "./gl";
 import { Teapot } from "./renderables/teapot";
-import { CrepuscularRay } from "./shaders/crepuscular_ray/shader"
+import { CrepuscularRay } from "./shaders/crepuscular_ray/shader";
 import { TransparentShader } from "./shaders/transparent/shader";
 import { FXAA } from "./shaders/fxaa/shader";
-import { vec3 } from "gl-matrix";
-import Matrix from "./matrix";
+import { Light } from "./light";
 
 $(() => {
   const $canvas: JQuery<HTMLCanvasElement> = $("canvas");
@@ -45,12 +45,7 @@ $(() => {
       0
     );
 
-    const light = {
-      position: vec3.fromValues(0, 10, -10),
-      color: vec3.fromValues(1, 1, 1),
-      power: 40,
-      matrix: new Matrix(gl),
-    }
+    const light = new Light(gl, { position: vec3.fromValues(0, 10, -10) });
 
     const transparentShader = new TransparentShader(gl, {
       opaqueDepthTexture: depthTexture,
@@ -67,9 +62,10 @@ $(() => {
       decay: 0.99,
       exposure: 0.0035,
     });
-   const fxaa = new FXAA(gl);
+    const fxaa = new FXAA(gl);
 
-    const path = "https://gist.githubusercontent.com/tinnywang/58bda00c65fd7b14d0d15ea1c7a022db/raw/e6147607586052300501fa6be58fc80c51ac6d15/teapot.json";
+    const path =
+      "https://gist.githubusercontent.com/tinnywang/58bda00c65fd7b14d0d15ea1c7a022db/raw/e6147607586052300501fa6be58fc80c51ac6d15/teapot.json";
 
     $.get(path, (data: string) => {
       const teapot = new Teapot(gl, JSON.parse(data)[0]);

--- a/src/light.ts
+++ b/src/light.ts
@@ -1,7 +1,9 @@
 import { vec3 } from "gl-matrix";
+import Matrix from "./matrix";
 
 export interface Light {
   position: vec3;
   color: vec3;
   power: number;
+  matrix: Matrix;
 }

--- a/src/light.ts
+++ b/src/light.ts
@@ -1,9 +1,59 @@
-import { vec3 } from "gl-matrix";
+import { glMatrix, mat4, vec3 } from "gl-matrix";
 import Matrix from "./matrix";
 
-export interface Light {
+export interface LightProps {
   position: vec3;
-  color: vec3;
-  power: number;
-  matrix: Matrix;
+  color?: vec3;
+  power?: number;
+  radius?: number;
+  degrees?: number;
+}
+
+export class Light {
+  private gl: WebGL2RenderingContext;
+
+  readonly position: vec3;
+
+  readonly color: vec3;
+
+  readonly power: number;
+
+  readonly radius: number;
+
+  readonly matrix: Matrix;
+
+  readonly vertices: number[];
+
+  readonly verticesBuffer: WebGLBuffer | null;
+
+  constructor(gl: WebGL2RenderingContext, props: LightProps) {
+    this.gl = gl;
+
+    this.position = props.position;
+    this.color = props.color ?? vec3.fromValues(1, 1, 1);
+    this.power = props.power ?? 1;
+    this.radius = props.radius ?? 1;
+    this.matrix = new Matrix(gl, mat4.fromTranslation(mat4.create(), this.position));
+
+    const degrees = props.degrees ?? 20;
+    this.vertices = this.getVertices(degrees);
+
+    this.verticesBuffer = gl.createBuffer();
+    gl.bindBuffer(this.gl.ARRAY_BUFFER, this.verticesBuffer);
+    gl.bufferData(this.gl.ARRAY_BUFFER, new Float32Array(this.vertices), gl.STATIC_DRAW);
+  }
+
+  // Points on a circle are given by the equation (x, y) = (rsin(θ), rcos(θ)).
+  // (0, 0) is the center of the circle and is the shared vertex in the triangle fan.
+  private getVertices(degrees: number): number[] {
+    const vertices = [0, 0];
+    for (let d = 0; d <= 360; d += degrees) {
+      vertices.push(
+        this.radius * Math.sin(glMatrix.toRadian(d)),
+        this.radius * Math.cos(glMatrix.toRadian(d)),
+      );
+    }
+
+    return vertices;
+  }
 }

--- a/src/shaders/crepuscular_ray/fragment.glsl
+++ b/src/shaders/crepuscular_ray/fragment.glsl
@@ -1,0 +1,31 @@
+#version 300 es
+
+precision highp float;
+
+in vec2 texturePosition;
+in vec2 lightRay;
+
+out vec4 fragColor;
+
+uniform sampler2D textureImage;
+uniform int samples;
+uniform float density;
+uniform float weight;
+uniform float decay;
+uniform float exposure;
+
+void main(void) {
+    vec2 delta = lightRay / float(samples) * density;
+    vec2 samplePosition = texturePosition;
+    float illuminationDecay = 1.0;
+    fragColor = texture(textureImage, texturePosition);
+
+    for (int i = 0; i < samples; i++) {
+        samplePosition -= delta;
+        vec4 sampleColor = texture(textureImage, samplePosition) * illuminationDecay * weight;
+        fragColor += sampleColor;
+        illuminationDecay *= decay;
+    }
+
+    fragColor *= exposure;
+}

--- a/src/shaders/crepuscular_ray/shader.ts
+++ b/src/shaders/crepuscular_ray/shader.ts
@@ -1,0 +1,73 @@
+import fragmentSrc from './fragment.glsl';
+import vertexSrc from './vertex.glsl';
+import { PostProcessing } from "../post_processing/shader";
+import { OcclusionShader } from "../occlusion/shader";
+import { Renderable } from '../../renderables/renderable';
+import WebGL2 from '../../gl';
+import { Light } from '../../light';
+
+export interface CrepuscularRayProps {
+    colorTexture: WebGLTexture;
+    light: Light;
+    samples: number;
+    density: number;
+    weight: number;
+    decay: number;
+    exposure: number;
+}
+
+export class CrepuscularRay extends PostProcessing {
+    private props: CrepuscularRayProps;
+    private occlusion: OcclusionShader;
+    private postProcessing: PostProcessing;
+
+    readonly texture: WebGLTexture;
+
+    constructor(gl: WebGL2RenderingContext, props: CrepuscularRayProps) {
+        super(gl, { vertexSrc, fragmentSrc });
+
+        this.props = props;
+        this.occlusion = new OcclusionShader(gl, { scale: 0.5 });
+        this.texture = WebGL2.createColorTextures(gl, 1)[0];
+        this.postProcessing = new PostProcessing(gl);
+
+        this.locations.setUniform('modelViewMatrix');
+        this.locations.setUniform('projectionMatrix');
+        this.locations.setUniform('lightPosition');
+        this.locations.setUniform('samples');
+        this.locations.setUniform('density');
+        this.locations.setUniform('weight');
+        this.locations.setUniform('decay');
+        this.locations.setUniform('exposure');
+        this.locations.setUniform('colorTexture');
+    }
+
+    render(drawFramebuffer: WebGLFramebuffer, ...renderables: Renderable[]) {
+        // Render occluding objects black and untextured.
+        this.occlusion.render(drawFramebuffer, ...renderables);
+
+        // Render crepescular rays from the occluding texture.
+        this.gl.useProgram(this.program);
+
+        this.gl.uniformMatrix4fv(this.locations.getUniform('modelViewMatrix'), false, this.props.light.matrix.modelView);
+        this.gl.uniformMatrix4fv(this.locations.getUniform('projectionMatrix'), false, this.props.light.matrix.projection);
+        this.gl.uniform3fv(this.locations.getUniform('lightPosition'), this.props.light.position);
+        this.gl.uniform1i(this.locations.getUniform('samples'), this.props.samples);
+        this.gl.uniform1f(this.locations.getUniform('density'), this.props.density);
+        this.gl.uniform1f(this.locations.getUniform('weight'), this.props.weight);
+        this.gl.uniform1f(this.locations.getUniform('decay'), this.props.decay);
+        this.gl.uniform1f(this.locations.getUniform('exposure'), this.props.exposure);
+
+        this.gl.framebufferTexture2D(this.gl.DRAW_FRAMEBUFFER, this.gl.COLOR_ATTACHMENT0, this.gl.TEXTURE_2D, this.texture, 0);
+        this.gl.clear(this.gl.COLOR_BUFFER_BIT);
+        super.render(this.occlusion.texture);
+
+        // Alpha-blend the crepuscular rays with the scene.
+        this.gl.disable(this.gl.DEPTH_TEST);
+        this.gl.enable(this.gl.BLEND);
+        this.gl.blendFunc(this.gl.SRC_ALPHA, this.gl.ONE_MINUS_SRC_ALPHA);
+
+        this.gl.framebufferTexture2D(this.gl.DRAW_FRAMEBUFFER, this.gl.COLOR_ATTACHMENT0, this.gl.TEXTURE_2D, this.props.colorTexture, 0);
+        this.postProcessing.render(this.texture);
+    }
+}

--- a/src/shaders/crepuscular_ray/vertex.glsl
+++ b/src/shaders/crepuscular_ray/vertex.glsl
@@ -1,0 +1,24 @@
+#version 300 es
+
+in vec2 vertexPosition;
+in vec3 lightPosition;
+
+out highp vec2 texturePosition;
+out highp vec2 lightRay;
+
+uniform mat4 modelViewMatrix;
+uniform mat4 projectionMatrix;
+
+void main(void) {
+    // gl_Position coordinates are in the range [-1, 1].
+    gl_Position = vec4(vertexPosition, 0, 1);
+
+    // Texture coordinates are in the range [0, 1].
+    texturePosition = vertexPosition * 0.5 + 0.5;
+
+    // Normalized-device coordinates (NDC) are in the rante [-1, 1].
+    vec4 lightPositionNDC = projectionMatrix * modelViewMatrix * vec4(lightPosition, 1);
+    lightPositionNDC /= lightPositionNDC.w;
+
+    lightRay = vertexPosition - lightPositionNDC.xy;
+}

--- a/src/shaders/fxaa/shader.ts
+++ b/src/shaders/fxaa/shader.ts
@@ -4,7 +4,7 @@ import { PostProcessing } from '../post_processing/shader';
 export class FXAA extends PostProcessing {
 
     constructor(gl: WebGL2RenderingContext) {
-        super(gl, fragmentSrc);
+        super(gl, { fragmentSrc });
     }
 
     render(texture: WebGLTexture) {

--- a/src/shaders/occlusion/fragment.glsl
+++ b/src/shaders/occlusion/fragment.glsl
@@ -1,0 +1,9 @@
+#version 300 es
+
+precision highp float;
+
+out vec4 fragColor;
+
+void main(void) {
+    fragColor = vec4(0, 0, 0, 1);
+}

--- a/src/shaders/occlusion/shader.ts
+++ b/src/shaders/occlusion/shader.ts
@@ -1,0 +1,70 @@
+import fragmentSrc from './fragment.glsl';
+import vertexSrc from './vertex.glsl';
+import { Shader } from '../shader';
+import { Renderable } from '../../renderables/renderable';
+import WebGL2 from '../../gl';
+
+export interface OcclusionProps {
+    scale: number;
+}
+
+export class OcclusionShader extends Shader {
+    private props: OcclusionProps;
+
+    readonly texture: WebGLTexture;
+
+    constructor(gl: WebGL2RenderingContext, props: OcclusionProps) {
+        super(gl, vertexSrc, fragmentSrc);
+
+        this.props = props;
+
+        this.texture = WebGL2.createColorTextures(
+            gl,
+            1,
+            gl.drawingBufferWidth * props.scale,
+            gl.drawingBufferHeight * props.scale,
+        )[0];
+
+        this.locations.setAttribute('vertexPosition');
+        this.locations.setUniform('modelViewMatrix');
+        this.locations.setUniform('projectionMatrix');
+    }
+
+    render(drawFramebuffer: WebGLFramebuffer, ...renderables: Renderable[]) {
+        super.render(drawFramebuffer, ...renderables);
+
+        this.gl.bindFramebuffer(this.gl.DRAW_FRAMEBUFFER, drawFramebuffer);
+        this.gl.framebufferTexture2D(this.gl.DRAW_FRAMEBUFFER, this.gl.COLOR_ATTACHMENT0, this.gl.TEXTURE_2D, this.texture, 0);
+        this.gl.framebufferTexture2D(this.gl.DRAW_FRAMEBUFFER, this.gl.DEPTH_ATTACHMENT, this.gl.TEXTURE_2D, null, 0);
+
+        const [x, y, width, height] = this.gl.getParameter(this.gl.VIEWPORT);
+        this.gl.viewport(
+            x * this.props.scale,
+            y * this.props.scale,
+            width * this.props.scale,
+            height * this.props.scale,
+        );
+        this.gl.disable(this.gl.DEPTH_TEST);
+        this.gl.clear(this.gl.COLOR_BUFFER_BIT);
+
+        renderables.forEach((r) => {
+            this.gl.bindBuffer(this.gl.ARRAY_BUFFER, r.buffer.vertices);
+            const vertexPosition = this.locations.getAttribute('vertexPosition');
+            this.gl.vertexAttribPointer(vertexPosition, 3, this.gl.FLOAT, false, 0, 0);
+            this.gl.enableVertexAttribArray(vertexPosition);
+
+            this.gl.uniformMatrix4fv(this.locations.getUniform('modelViewMatrix'), false, r.matrix.modelView);
+            this.gl.uniformMatrix4fv(this.locations.getUniform('projectionMatrix'), false, r.matrix.projection);
+
+            let offset = 0;
+            this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, r.buffer.faces);
+            r.object.faces.forEach((f) => {
+                this.gl.drawElements(this.gl.TRIANGLES, f.vertex_indices.length, this.gl.UNSIGNED_SHORT, offset);
+                // Offset must be a multiple of 2 since an unsigned short is 2 bytes.
+                offset += f.vertex_indices.length * 2;
+            })
+        });
+
+        this.gl.viewport(x, y, width, height);
+    }
+}

--- a/src/shaders/occlusion/vertex.glsl
+++ b/src/shaders/occlusion/vertex.glsl
@@ -1,0 +1,10 @@
+#version 300 es
+
+in vec4 vertexPosition;
+
+uniform mat4 modelViewMatrix;
+uniform mat4 projectionMatrix;
+
+void main(void) {
+    gl_Position = projectionMatrix * modelViewMatrix * vertexPosition;
+}

--- a/src/shaders/post_processing/shader.ts
+++ b/src/shaders/post_processing/shader.ts
@@ -1,6 +1,11 @@
 import vertexSrc from './vertex.glsl';
-import identityFragmentSrc from './fragment.glsl';
+import fragmentSrc from './fragment.glsl';
 import { Shader } from '../shader';
+
+export interface PostProcessingProps {
+    vertexSrc?: string;
+    fragmentSrc?: string;
+}
 
 export class PostProcessing extends Shader {
     // These are already in normalized device coordinates and don't need to be
@@ -16,8 +21,8 @@ export class PostProcessing extends Shader {
 
     private verticesBuffer: WebGLBuffer | null;
 
-    constructor(gl: WebGL2RenderingContext, fragmentSrc?: string) {
-        super(gl, vertexSrc, fragmentSrc ?? identityFragmentSrc);
+    constructor(gl: WebGL2RenderingContext, props?: PostProcessingProps) {
+        super(gl, props?.vertexSrc ?? vertexSrc, props?.fragmentSrc ?? fragmentSrc);
 
         this.locations.setAttribute('vertexPosition');
         this.locations.setUniform('textureImage');

--- a/src/shaders/post_processing/vertex.glsl
+++ b/src/shaders/post_processing/vertex.glsl
@@ -4,12 +4,10 @@ in vec2 vertexPosition;
 
 out highp vec2 texturePosition;
 
-const vec2 scale = vec2(0.5, 0.5);
-
 void main(void) {
     // gl_Position coordinates are in the range [-1, 1].
     gl_Position = vec4(vertexPosition, 0, 1);
 
     // Texture coordinates are in the range [0, 1].
-    texturePosition = vertexPosition * scale + scale;
+    texturePosition = vertexPosition * 0.5 + 0.5;
 }


### PR DESCRIPTION
Implement crepuscular rays, according to the [Occlusion Pre-Pass Method](https://developer.nvidia.com/gpugems/gpugems3/part-ii-light-and-shadows/chapter-13-volumetric-light-scattering-post-process).
- The occlusion shader renders objects as solid black to a texture. (It doesn't render light sources as white.)
- The crepuscular ray shader uses the texture from the occlusion shader to render crepuscular rays to its own texture.
- The crepuscular ray texture is alpha-blended with the scene's color texture, which has the objects rendered with normal lighting.

![image](https://user-images.githubusercontent.com/1168893/212791017-073b1081-999f-4b32-b73c-92761344e1f4.png)
