### PR TITLE
Refactor renderables

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,7 @@
 import $ from "jquery";
 import { vec3 } from "gl-matrix";
 import WebGL2 from "./gl";
-import { Teapot } from "./renderables/teapot";
+import { Teapot } from "./models/teapot";
 import { CrepuscularRay } from "./shaders/crepuscular_ray/shader";
 import { TransparentShader } from "./shaders/transparent/shader";
 import { FXAA } from "./shaders/fxaa/shader";

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,8 +73,8 @@ $(() => {
       const render = (_: DOMHighResTimeStamp) => {
         gl.clear(gl.COLOR_BUFFER_BIT | gl.DEPTH_BUFFER_BIT);
 
-        transparentShader.render(framebuffer, teapot);
-        crepuscularRay.render(framebuffer, teapot);
+        transparentShader.render(framebuffer, [teapot]);
+        crepuscularRay.render(framebuffer, [teapot]);
 
         gl.bindFramebuffer(gl.READ_FRAMEBUFFER, framebuffer);
         gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);

--- a/src/light.ts
+++ b/src/light.ts
@@ -48,15 +48,25 @@ export class Light {
   }
 
   render(gl: WebGL2RenderingContext, locations: ShaderLocations) {
-    const vertexPosition = locations.getAttribute('vertexPosition');
+    const vertexPosition = locations.getAttribute("vertexPosition");
     if (vertexPosition !== null) {
       gl.bindBuffer(gl.ARRAY_BUFFER, this.verticesBuffer);
       gl.vertexAttribPointer(vertexPosition, 2, gl.FLOAT, false, 0, 0);
       gl.enableVertexAttribArray(vertexPosition);
     }
 
-    gl.uniformMatrix4fv(locations.getUniform('modelViewMatrix'), false, this.matrix.modelView);
-    gl.uniformMatrix4fv(locations.getUniform('projectionMatrix'), false, this.matrix.projection);
+    gl.uniformMatrix4fv(
+      locations.getUniform("modelViewMatrix"),
+      false,
+      this.matrix.modelView
+    );
+    gl.uniformMatrix4fv(
+      locations.getUniform("projectionMatrix"),
+      false,
+      this.matrix.projection
+    );
+
+    gl.uniform3fv(locations.getUniform("color"), this.color);
 
     gl.drawArrays(gl.TRIANGLE_FAN, 0, this.vertices.length);
   }

--- a/src/light.ts
+++ b/src/light.ts
@@ -33,14 +33,21 @@ export class Light {
     this.color = props.color ?? vec3.fromValues(1, 1, 1);
     this.power = props.power ?? 1;
     this.radius = props.radius ?? 1;
-    this.matrix = new Matrix(gl, mat4.fromTranslation(mat4.create(), this.position));
+    this.matrix = new Matrix(
+      gl,
+      mat4.fromTranslation(mat4.create(), this.position)
+    );
 
     const degrees = props.degrees ?? 20;
     this.vertices = this.getVertices(degrees);
 
     this.verticesBuffer = gl.createBuffer();
     gl.bindBuffer(this.gl.ARRAY_BUFFER, this.verticesBuffer);
-    gl.bufferData(this.gl.ARRAY_BUFFER, new Float32Array(this.vertices), gl.STATIC_DRAW);
+    gl.bufferData(
+      this.gl.ARRAY_BUFFER,
+      new Float32Array(this.vertices),
+      gl.STATIC_DRAW
+    );
   }
 
   // Points on a circle are given by the equation (x, y) = (rsin(θ), rcos(θ)).
@@ -50,7 +57,7 @@ export class Light {
     for (let d = 0; d <= 360; d += degrees) {
       vertices.push(
         this.radius * Math.sin(glMatrix.toRadian(d)),
-        this.radius * Math.cos(glMatrix.toRadian(d)),
+        this.radius * Math.cos(glMatrix.toRadian(d))
       );
     }
 

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -1,6 +1,7 @@
 import { mat4 } from "gl-matrix";
-import { Object } from "../object";
+import { Face, Object } from "../object";
 import Matrix from "../matrix";
+import { ShaderLocations } from "../shaders/shader_locations";
 
 interface Buffer {
   vertices: WebGLBuffer | null;
@@ -55,6 +56,35 @@ export abstract class Model {
     this.gl = gl;
     this.matrix = new Matrix(gl, model);
     this.object = o;
+  }
+
+  render(gl: WebGL2RenderingContext, locations: ShaderLocations, perFace?: (f: Face) => void) {
+    const vertexPosition = locations.getAttribute('vertexPosition');
+    if (vertexPosition !== null) {
+      gl.bindBuffer(gl.ARRAY_BUFFER, this.buffer.vertices);
+      gl.vertexAttribPointer(vertexPosition, 3, this.gl.FLOAT, false, 0, 0);
+      gl.enableVertexAttribArray(vertexPosition);
+    }
+
+    const normal = locations.getAttribute('normal');
+    if (normal !== null) {
+      this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.buffer.normals);
+      this.gl.vertexAttribPointer(normal, 3, this.gl.FLOAT, false, 0, 0);
+      this.gl.enableVertexAttribArray(normal);
+    }
+
+    gl.uniformMatrix4fv(locations.getUniform('modelViewMatrix'), false, this.matrix.modelView);
+    gl.uniformMatrix4fv(locations.getUniform('projectionMatrix'), false, this.matrix.projection);
+
+    let offset = 0;
+    gl.bindBuffer(gl.ELEMENT_ARRAY_BUFFER, this.buffer.faces);
+    this.object.faces.forEach((f) => {
+      perFace?.(f);
+
+      this.gl.drawElements(this.gl.TRIANGLES, f.vertex_indices.length, this.gl.UNSIGNED_SHORT, offset)
+      // Offset must be a multiple of 2 since an unsigned short is 2 bytes.
+      offset += f.vertex_indices.length * 2
+    })
   }
 }
 

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -8,7 +8,7 @@ interface Buffer {
   normals: WebGLBuffer | null;
 }
 
-export abstract class Renderable {
+export abstract class Model {
   readonly buffer: Buffer;
 
   readonly gl: WebGL2RenderingContext;

--- a/src/models/teapot.ts
+++ b/src/models/teapot.ts
@@ -1,8 +1,8 @@
 import { mat4, glMatrix } from "gl-matrix";
 import { Object } from "../object";
-import { Renderable } from "./renderable";
+import { Model } from "./model";
 
-export class Teapot extends Renderable {
+export class Teapot extends Model {
     constructor(gl: WebGL2RenderingContext, o: Object) {
         let model = mat4.rotateX(
             mat4.create(),

--- a/src/object.ts
+++ b/src/object.ts
@@ -9,7 +9,7 @@ interface Material {
   specular_exponent: number;
 }
 
-interface Face {
+export interface Face {
   material: Material;
   vertex_indices: Array<number>;
 }

--- a/src/shaders/blinn_phong/shader.ts
+++ b/src/shaders/blinn_phong/shader.ts
@@ -1,9 +1,9 @@
-import vertexSrc from './vertex.glsl'
-import fragmentSrc from './fragment.glsl'
-import { Shader } from '../shader'
-import { Renderable } from '../../renderables/renderable'
-import Matrix from '../../matrix'
-import { Light } from '../../light'
+import vertexSrc from './vertex.glsl';
+import fragmentSrc from './fragment.glsl';
+import { Shader } from '../shader';
+import { Model } from '../../models/model';
+import Matrix from '../../matrix';
+import { Light } from '../../light';
 
 export class BlinnPhongShader extends Shader {
     private readonly lights: Light[];
@@ -30,8 +30,8 @@ export class BlinnPhongShader extends Shader {
         });
     }
 
-    render(drawFramebuffer: WebGLFramebuffer, ...renderables: Renderable[]) {
-        super.render(drawFramebuffer, ...renderables);
+    render(drawFramebuffer: WebGLFramebuffer, ...models: Model[]) {
+        super.render(drawFramebuffer, ...models);
 
         this.gl.enable(this.gl.DEPTH_TEST);
         this.gl.depthFunc(this.gl.LEQUAL)
@@ -48,23 +48,23 @@ export class BlinnPhongShader extends Shader {
             this.gl.uniform1f(this.locations.getUniform(`lights[${i}].power`), light.power);
         });
 
-        renderables.forEach((r) => {
-            this.gl.bindBuffer(this.gl.ARRAY_BUFFER, r.buffer.vertices);
+        models.forEach((m) => {
+            this.gl.bindBuffer(this.gl.ARRAY_BUFFER, m.buffer.vertices);
             const vertexPosition = this.locations.getAttribute('vertexPosition');
             this.gl.vertexAttribPointer(vertexPosition, 3, this.gl.FLOAT, false, 0, 0);
             this.gl.enableVertexAttribArray(vertexPosition);
 
-            this.gl.bindBuffer(this.gl.ARRAY_BUFFER, r.buffer.normals);
+            this.gl.bindBuffer(this.gl.ARRAY_BUFFER, m.buffer.normals);
             const normal = this.locations.getAttribute('normal');
             this.gl.vertexAttribPointer(normal, 3, this.gl.FLOAT, false, 0, 0);
             this.gl.enableVertexAttribArray(normal);
 
-            this.gl.uniformMatrix4fv(this.locations.getUniform('modelViewMatrix'), false, r.matrix.modelView);
-            this.gl.uniformMatrix4fv(this.locations.getUniform('projectionMatrix'), false, r.matrix.projection);
+            this.gl.uniformMatrix4fv(this.locations.getUniform('modelViewMatrix'), false, m.matrix.modelView);
+            this.gl.uniformMatrix4fv(this.locations.getUniform('projectionMatrix'), false, m.matrix.projection);
 
             let offset = 0
-            this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, r.buffer.faces);
-            r.object.faces.forEach((f) => {
+            this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, m.buffer.faces);
+            m.object.faces.forEach((f) => {
                 this.gl.uniform3fv(this.locations.getUniform('material.ambient'), f.material.ambient);
                 this.gl.uniform3fv(this.locations.getUniform('material.diffuse'), f.material.diffuse);
                 this.gl.uniform3fv(this.locations.getUniform('material.specular'), f.material.specular);

--- a/src/shaders/blinn_phong/shader.ts
+++ b/src/shaders/blinn_phong/shader.ts
@@ -6,11 +6,15 @@ import Matrix from '../../matrix';
 import { Light } from '../../light';
 import { Face } from '../../object';
 
+export interface BlinnPhongProps {
+    lights: Light[];
+}
+
 export class BlinnPhongShader extends Shader {
     private readonly lights: Light[];
 
-    constructor(gl: WebGL2RenderingContext, lights: Light[]) {
-        super(gl, vertexSrc, fragmentSrc.replace('${numLights}', lights.length.toString()));
+    constructor(gl: WebGL2RenderingContext, props: BlinnPhongProps) {
+        super(gl, vertexSrc, fragmentSrc.replace('${numLights}', props.lights.length.toString()));
 
         this.locations.setAttribute('vertexPosition');
         this.locations.setUniform('modelViewMatrix');
@@ -23,7 +27,7 @@ export class BlinnPhongShader extends Shader {
         this.locations.setUniform('material.specular');
         this.locations.setUniform('material.specularExponent');
 
-        this.lights = lights;
+        this.lights = props.lights;
         this.lights.forEach((_, i) => {
             this.locations.setUniform(`lights[${i}].position`);
             this.locations.setUniform(`lights[${i}].color`);
@@ -31,8 +35,8 @@ export class BlinnPhongShader extends Shader {
         });
     }
 
-    render(drawFramebuffer: WebGLFramebuffer, ...models: Model[]) {
-        super.render(drawFramebuffer, ...models);
+    render(drawFramebuffer: WebGLFramebuffer, models?: Model[]) {
+        super.render(drawFramebuffer, models);
 
         this.gl.enable(this.gl.DEPTH_TEST);
         this.gl.depthFunc(this.gl.LEQUAL)
@@ -49,8 +53,8 @@ export class BlinnPhongShader extends Shader {
             this.gl.uniform1f(this.locations.getUniform(`lights[${i}].power`), light.power);
         });
 
-        models.forEach((model) => {
-            model.render(this.gl, this.locations, (f: Face) => {
+        models?.forEach((m) => {
+            m.render(this.gl, this.locations, (f: Face) => {
                 this.gl.uniform3fv(this.locations.getUniform('material.ambient'), f.material.ambient);
                 this.gl.uniform3fv(this.locations.getUniform('material.diffuse'), f.material.diffuse);
                 this.gl.uniform3fv(this.locations.getUniform('material.specular'), f.material.specular);

--- a/src/shaders/crepuscular_ray/shader.ts
+++ b/src/shaders/crepuscular_ray/shader.ts
@@ -42,9 +42,9 @@ export class CrepuscularRay extends PostProcessing {
         this.locations.setUniform('colorTexture');
     }
 
-    render(drawFramebuffer: WebGLFramebuffer, ...models: Model[]) {
+    render(drawFramebuffer: WebGLFramebuffer, models?: Model[]) {
         // Render occluding objects black and untextured.
-        this.occlusion.render(drawFramebuffer, ...models);
+        this.occlusion.render(drawFramebuffer, models);
 
         // Render crepescular rays from the occluding texture.
         this.gl.useProgram(this.program);

--- a/src/shaders/crepuscular_ray/shader.ts
+++ b/src/shaders/crepuscular_ray/shader.ts
@@ -2,7 +2,7 @@ import fragmentSrc from './fragment.glsl';
 import vertexSrc from './vertex.glsl';
 import { PostProcessing } from "../post_processing/shader";
 import { OcclusionShader } from "../occlusion/shader";
-import { Renderable } from '../../renderables/renderable';
+import { Model } from '../../models/model';
 import WebGL2 from '../../gl';
 import { Light } from '../../light';
 
@@ -42,9 +42,9 @@ export class CrepuscularRay extends PostProcessing {
         this.locations.setUniform('colorTexture');
     }
 
-    render(drawFramebuffer: WebGLFramebuffer, ...renderables: Renderable[]) {
+    render(drawFramebuffer: WebGLFramebuffer, ...models: Model[]) {
         // Render occluding objects black and untextured.
-        this.occlusion.render(drawFramebuffer, ...renderables);
+        this.occlusion.render(drawFramebuffer, ...models);
 
         // Render crepescular rays from the occluding texture.
         this.gl.useProgram(this.program);

--- a/src/shaders/occlusion/fragment.glsl
+++ b/src/shaders/occlusion/fragment.glsl
@@ -4,6 +4,8 @@ precision highp float;
 
 out vec4 fragColor;
 
+uniform vec3 color;
+
 void main(void) {
-    fragColor = vec4(0, 0, 0, 1);
+    fragColor = vec4(color, 1);
 }

--- a/src/shaders/occlusion/shader.ts
+++ b/src/shaders/occlusion/shader.ts
@@ -1,7 +1,7 @@
 import fragmentSrc from './fragment.glsl';
 import vertexSrc from './vertex.glsl';
 import { Shader } from '../shader';
-import { Renderable } from '../../renderables/renderable';
+import { Model } from '../../models/model';
 import WebGL2 from '../../gl';
 
 export interface OcclusionProps {
@@ -30,8 +30,8 @@ export class OcclusionShader extends Shader {
         this.locations.setUniform('projectionMatrix');
     }
 
-    render(drawFramebuffer: WebGLFramebuffer, ...renderables: Renderable[]) {
-        super.render(drawFramebuffer, ...renderables);
+    render(drawFramebuffer: WebGLFramebuffer, ...models: Model[]) {
+        super.render(drawFramebuffer, ...models);
 
         this.gl.bindFramebuffer(this.gl.DRAW_FRAMEBUFFER, drawFramebuffer);
         this.gl.framebufferTexture2D(this.gl.DRAW_FRAMEBUFFER, this.gl.COLOR_ATTACHMENT0, this.gl.TEXTURE_2D, this.texture, 0);
@@ -47,18 +47,18 @@ export class OcclusionShader extends Shader {
         this.gl.disable(this.gl.DEPTH_TEST);
         this.gl.clear(this.gl.COLOR_BUFFER_BIT);
 
-        renderables.forEach((r) => {
-            this.gl.bindBuffer(this.gl.ARRAY_BUFFER, r.buffer.vertices);
+        models.forEach((m) => {
+            this.gl.bindBuffer(this.gl.ARRAY_BUFFER, m.buffer.vertices);
             const vertexPosition = this.locations.getAttribute('vertexPosition');
             this.gl.vertexAttribPointer(vertexPosition, 3, this.gl.FLOAT, false, 0, 0);
             this.gl.enableVertexAttribArray(vertexPosition);
 
-            this.gl.uniformMatrix4fv(this.locations.getUniform('modelViewMatrix'), false, r.matrix.modelView);
-            this.gl.uniformMatrix4fv(this.locations.getUniform('projectionMatrix'), false, r.matrix.projection);
+            this.gl.uniformMatrix4fv(this.locations.getUniform('modelViewMatrix'), false, m.matrix.modelView);
+            this.gl.uniformMatrix4fv(this.locations.getUniform('projectionMatrix'), false, m.matrix.projection);
 
             let offset = 0;
-            this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, r.buffer.faces);
-            r.object.faces.forEach((f) => {
+            this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, m.buffer.faces);
+            m.object.faces.forEach((f) => {
                 this.gl.drawElements(this.gl.TRIANGLES, f.vertex_indices.length, this.gl.UNSIGNED_SHORT, offset);
                 // Offset must be a multiple of 2 since an unsigned short is 2 bytes.
                 offset += f.vertex_indices.length * 2;

--- a/src/shaders/occlusion/shader.ts
+++ b/src/shaders/occlusion/shader.ts
@@ -1,9 +1,10 @@
 import fragmentSrc from './fragment.glsl';
 import vertexSrc from './vertex.glsl';
-import { Renderable, Shader } from '../shader';
+import { Shader } from '../shader';
 import WebGL2 from '../../gl';
 import { vec3 } from 'gl-matrix';
 import { Light } from '../../light';
+import { Model } from '../../models/model';
 
 export interface OcclusionProps {
     scale: number;
@@ -34,8 +35,8 @@ export class OcclusionShader extends Shader {
         this.locations.setUniform('color');
     }
 
-    render(drawFramebuffer: WebGLFramebuffer, ...renderables: Renderable[]) {
-        super.render(drawFramebuffer, ...renderables);
+    render(drawFramebuffer: WebGLFramebuffer, models?: Model[], lights?: Light[]) {
+        super.render(drawFramebuffer, models, lights);
 
         this.gl.bindFramebuffer(this.gl.DRAW_FRAMEBUFFER, drawFramebuffer);
         this.gl.framebufferTexture2D(this.gl.DRAW_FRAMEBUFFER, this.gl.COLOR_ATTACHMENT0, this.gl.TEXTURE_2D, this.texture, 0);
@@ -51,12 +52,10 @@ export class OcclusionShader extends Shader {
         this.gl.disable(this.gl.DEPTH_TEST);
         this.gl.clear(this.gl.COLOR_BUFFER_BIT);
 
+        this.gl.uniform3fv(this.locations.getUniform('color'), OcclusionShader.Black);
+        models?.forEach((m) => m.render(this.gl, this.locations));
 
-        renderables.forEach((r) => {
-            const color = r instanceof Light ? r.color : OcclusionShader.Black;
-            this.gl.uniform3fv(this.locations.getUniform('color'), color);
-            r.render(this.gl, this.locations);
-        });
+        lights?.forEach((l) => l.render(this.gl, this.locations));
 
         this.gl.viewport(x, y, width, height);
     }

--- a/src/shaders/occlusion/shader.ts
+++ b/src/shaders/occlusion/shader.ts
@@ -47,23 +47,7 @@ export class OcclusionShader extends Shader {
         this.gl.disable(this.gl.DEPTH_TEST);
         this.gl.clear(this.gl.COLOR_BUFFER_BIT);
 
-        models.forEach((m) => {
-            this.gl.bindBuffer(this.gl.ARRAY_BUFFER, m.buffer.vertices);
-            const vertexPosition = this.locations.getAttribute('vertexPosition');
-            this.gl.vertexAttribPointer(vertexPosition, 3, this.gl.FLOAT, false, 0, 0);
-            this.gl.enableVertexAttribArray(vertexPosition);
-
-            this.gl.uniformMatrix4fv(this.locations.getUniform('modelViewMatrix'), false, m.matrix.modelView);
-            this.gl.uniformMatrix4fv(this.locations.getUniform('projectionMatrix'), false, m.matrix.projection);
-
-            let offset = 0;
-            this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, m.buffer.faces);
-            m.object.faces.forEach((f) => {
-                this.gl.drawElements(this.gl.TRIANGLES, f.vertex_indices.length, this.gl.UNSIGNED_SHORT, offset);
-                // Offset must be a multiple of 2 since an unsigned short is 2 bytes.
-                offset += f.vertex_indices.length * 2;
-            })
-        });
+        models.forEach((m) => m.render(this.gl, this.locations));
 
         this.gl.viewport(x, y, width, height);
     }

--- a/src/shaders/post_processing/shader.ts
+++ b/src/shaders/post_processing/shader.ts
@@ -35,10 +35,12 @@ export class PostProcessing extends Shader {
     render(texture: WebGLTexture) {
         super.render(texture);
 
-        this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.verticesBuffer);
         const vertexPosition = this.locations.getAttribute('vertexPosition');
-        this.gl.vertexAttribPointer(vertexPosition, 2, this.gl.FLOAT, false, 0, 0);
-        this.gl.enableVertexAttribArray(vertexPosition);
+        if (vertexPosition !== null) {
+            this.gl.bindBuffer(this.gl.ARRAY_BUFFER, this.verticesBuffer);
+            this.gl.vertexAttribPointer(vertexPosition, 2, this.gl.FLOAT, false, 0, 0);
+            this.gl.enableVertexAttribArray(vertexPosition);
+        }
 
         this.gl.activeTexture(this.gl.TEXTURE0);
         this.gl.bindTexture(this.gl.TEXTURE_2D, texture);

--- a/src/shaders/shader.ts
+++ b/src/shaders/shader.ts
@@ -1,3 +1,4 @@
+import { Light } from '../light';
 import { Model } from '../models/model';
 import { ShaderLocations } from './shader_locations';
 
@@ -47,7 +48,9 @@ export abstract class Shader {
       return shader
     }
 
-    render(_framebuffer: WebGLFramebuffer, ..._models: Model[]) {
+    render(_framebuffer: WebGLFramebuffer, ..._renderables: Renderable[]) {
       this.gl.useProgram(this.program);
     }
 }
+
+export type Renderable = Model | Light;

--- a/src/shaders/shader.ts
+++ b/src/shaders/shader.ts
@@ -1,4 +1,4 @@
-import { Renderable } from '../renderables/renderable';
+import { Model } from '../models/model';
 import { ShaderLocations } from './shader_locations';
 
 export abstract class Shader {
@@ -47,7 +47,7 @@ export abstract class Shader {
       return shader
     }
 
-    render(_framebuffer: WebGLFramebuffer, ..._renderables: Renderable[]) {
+    render(_framebuffer: WebGLFramebuffer, ..._models: Model[]) {
       this.gl.useProgram(this.program);
     }
 }

--- a/src/shaders/shader.ts
+++ b/src/shaders/shader.ts
@@ -48,9 +48,7 @@ export abstract class Shader {
       return shader
     }
 
-    render(_framebuffer: WebGLFramebuffer, ..._renderables: Renderable[]) {
+    render(_data: WebGLFramebuffer | WebGLTexture, _models?: Model[], _lights?: Light[]) {
       this.gl.useProgram(this.program);
     }
 }
-
-export type Renderable = Model | Light;

--- a/src/shaders/shader_locations.ts
+++ b/src/shaders/shader_locations.ts
@@ -21,8 +21,8 @@ export class ShaderLocations {
 		this.uniforms.set(name, locations);
 	}
 
-	getAttribute(name: string): GLint {
-		return this.attributes.get(name) ?? -1;
+	getAttribute(name: string): GLint | null {
+		return this.attributes.get(name) ?? null;
 	}
 
 	setAttribute(name: string) {

--- a/src/shaders/transparent/shader.ts
+++ b/src/shaders/transparent/shader.ts
@@ -2,7 +2,7 @@ import vertexSrc from './vertex.glsl';
 import fragmentSrc from './fragment.glsl';
 import { Shader } from '../shader';
 import { PostProcessing } from '../post_processing/shader';
-import { Renderable } from '../../renderables/renderable';
+import { Model } from '../../models/model';
 import WebGL2 from '../../gl';
 import Matrix from '../../matrix';
 import { vec3 } from 'gl-matrix';
@@ -52,8 +52,8 @@ export class TransparentShader extends Shader {
         this.locations.setUniform('fresnelExponent');
     }
 
-    render(drawFramebuffer: WebGLFramebuffer, ...renderables: Renderable[]) {
-        super.render(drawFramebuffer, ...renderables);
+    render(drawFramebuffer: WebGLFramebuffer, ...models: Model[]) {
+        super.render(drawFramebuffer, ...models);
 
         this.gl.uniform3fv(this.locations.getUniform('eye'), Matrix.EYE);
         this.gl.uniform3fv(this.locations.getUniform('fresnelColor'), this.props.fresnelColor);
@@ -68,23 +68,23 @@ export class TransparentShader extends Shader {
         for (let i = 0; i < NUM_PASSES; i++) {
             this.depthPeel(i);
 
-            renderables.forEach((r) => {
-                this.gl.bindBuffer(this.gl.ARRAY_BUFFER, r.buffer.vertices);
+            models.forEach((m) => {
+                this.gl.bindBuffer(this.gl.ARRAY_BUFFER, m.buffer.vertices);
                 const vertexPosition = this.locations.getAttribute('vertexPosition');
                 this.gl.vertexAttribPointer(vertexPosition, 3, this.gl.FLOAT, false, 0, 0);
                 this.gl.enableVertexAttribArray(vertexPosition);
 
-                this.gl.bindBuffer(this.gl.ARRAY_BUFFER, r.buffer.normals);
+                this.gl.bindBuffer(this.gl.ARRAY_BUFFER, m.buffer.normals);
                 const normal = this.locations.getAttribute('normal');
                 this.gl.vertexAttribPointer(normal, 3, this.gl.FLOAT, false, 0, 0);
                 this.gl.enableVertexAttribArray(normal);
 
-                this.gl.uniformMatrix4fv(this.locations.getUniform('modelViewMatrix'), false, r.matrix.modelView);
-                this.gl.uniformMatrix4fv(this.locations.getUniform('projectionMatrix'), false, r.matrix.projection);
+                this.gl.uniformMatrix4fv(this.locations.getUniform('modelViewMatrix'), false, m.matrix.modelView);
+                this.gl.uniformMatrix4fv(this.locations.getUniform('projectionMatrix'), false, m.matrix.projection);
 
                 let offset = 0;
-                this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, r.buffer.faces);
-                r.object.faces.forEach((f) => {
+                this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, m.buffer.faces);
+                m.object.faces.forEach((f) => {
                     this.gl.uniform3fv(this.locations.getUniform('color'), f.material.diffuse);
 
                     this.gl.drawElements(this.gl.TRIANGLES, f.vertex_indices.length, this.gl.UNSIGNED_SHORT, offset);

--- a/src/shaders/transparent/shader.ts
+++ b/src/shaders/transparent/shader.ts
@@ -53,8 +53,8 @@ export class TransparentShader extends Shader {
         this.locations.setUniform('fresnelExponent');
     }
 
-    render(drawFramebuffer: WebGLFramebuffer, ...models: Model[]) {
-        super.render(drawFramebuffer, ...models);
+    render(drawFramebuffer: WebGLFramebuffer, models?: Model[]) {
+        super.render(drawFramebuffer, models);
 
         this.gl.uniform3fv(this.locations.getUniform('eye'), Matrix.EYE);
         this.gl.uniform3fv(this.locations.getUniform('fresnelColor'), this.props.fresnelColor);
@@ -69,7 +69,7 @@ export class TransparentShader extends Shader {
         for (let i = 0; i < NUM_PASSES; i++) {
             this.depthPeel(i);
 
-            models.forEach((m) => {
+            models?.forEach((m) => {
                 m.render(this.gl, this.locations, (f: Face) => {
                     this.gl.uniform3fv(this.locations.getUniform('color'), f.material.diffuse);
                 });

--- a/src/shaders/transparent/shader.ts
+++ b/src/shaders/transparent/shader.ts
@@ -6,6 +6,7 @@ import { Model } from '../../models/model';
 import WebGL2 from '../../gl';
 import Matrix from '../../matrix';
 import { vec3 } from 'gl-matrix';
+import { Face } from '../../object';
 
 const NUM_PASSES = 4;
 
@@ -69,28 +70,9 @@ export class TransparentShader extends Shader {
             this.depthPeel(i);
 
             models.forEach((m) => {
-                this.gl.bindBuffer(this.gl.ARRAY_BUFFER, m.buffer.vertices);
-                const vertexPosition = this.locations.getAttribute('vertexPosition');
-                this.gl.vertexAttribPointer(vertexPosition, 3, this.gl.FLOAT, false, 0, 0);
-                this.gl.enableVertexAttribArray(vertexPosition);
-
-                this.gl.bindBuffer(this.gl.ARRAY_BUFFER, m.buffer.normals);
-                const normal = this.locations.getAttribute('normal');
-                this.gl.vertexAttribPointer(normal, 3, this.gl.FLOAT, false, 0, 0);
-                this.gl.enableVertexAttribArray(normal);
-
-                this.gl.uniformMatrix4fv(this.locations.getUniform('modelViewMatrix'), false, m.matrix.modelView);
-                this.gl.uniformMatrix4fv(this.locations.getUniform('projectionMatrix'), false, m.matrix.projection);
-
-                let offset = 0;
-                this.gl.bindBuffer(this.gl.ELEMENT_ARRAY_BUFFER, m.buffer.faces);
-                m.object.faces.forEach((f) => {
+                m.render(this.gl, this.locations, (f: Face) => {
                     this.gl.uniform3fv(this.locations.getUniform('color'), f.material.diffuse);
-
-                    this.gl.drawElements(this.gl.TRIANGLES, f.vertex_indices.length, this.gl.UNSIGNED_SHORT, offset);
-                    // Offset must be a multiple of 2 since an unsigned short is 2 bytes.
-                    offset += f.vertex_indices.length * 2;
-                })
+                });
             });
         }
 


### PR DESCRIPTION
- Rename the `Renderable` class to `Model`.
- Refactor common logic for rendering models out of shaders and into `Model.render`.
- Make lights renderable.