### PR TITLE
Glowing orbs of light

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -55,7 +55,6 @@ $(() => {
     });
     const crepuscularRay = new CrepuscularRay(gl, {
       colorTexture,
-      light,
       samples: 50,
       density: 0.35,
       weight: 5,

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,3 @@
-// import { vec3 } from "gl-matrix";
 import $ from "jquery";
 import { vec3 } from "gl-matrix";
 import WebGL2 from "./gl";
@@ -7,6 +6,7 @@ import { CrepuscularRay } from "./shaders/crepuscular_ray/shader";
 import { TransparentShader } from "./shaders/transparent/shader";
 import { FXAA } from "./shaders/fxaa/shader";
 import { Light } from "./light";
+import { Glow } from "./shaders/glow/shader";
 
 $(() => {
   const $canvas: JQuery<HTMLCanvasElement> = $("canvas");
@@ -45,7 +45,22 @@ $(() => {
       0
     );
 
-    const light = new Light(gl, { position: vec3.fromValues(0, 10, -10) });
+    const light = new Light(gl, { positions: [vec3.fromValues(0, 10, -10)] });
+    const glowLights = [
+      new Light(gl, {
+        positions: [
+          vec3.fromValues(0, 1, 0),
+          vec3.fromValues(0.25, 0.35, 3.25),
+        ],
+        radius: 50,
+        color: vec3.fromValues(1, 0, 0.5),
+      }),
+      new Light(gl, {
+        positions: [vec3.fromValues(-0.35, 0.35, 0)],
+        radius: 25,
+        color: vec3.fromValues(1, 0, 0.5),
+      }),
+    ];
 
     const transparentShader = new TransparentShader(gl, {
       opaqueDepthTexture: depthTexture,
@@ -61,6 +76,7 @@ $(() => {
       decay: 0.99,
       exposure: 0.0035,
     });
+    const glow = new Glow(gl);
     const fxaa = new FXAA(gl);
 
     const path =
@@ -74,6 +90,7 @@ $(() => {
 
         transparentShader.render(framebuffer, teapot);
         crepuscularRay.render(framebuffer, { models: [teapot], light });
+        glow.render(framebuffer, ...glowLights);
 
         gl.bindFramebuffer(gl.READ_FRAMEBUFFER, framebuffer);
         gl.bindFramebuffer(gl.DRAW_FRAMEBUFFER, null);

--- a/src/index.ts
+++ b/src/index.ts
@@ -45,7 +45,9 @@ $(() => {
       0
     );
 
-    const light = new Light(gl, { positions: [vec3.fromValues(0, 10, -10)] });
+    const light = new Light(gl, {
+      positions: [vec3.fromValues(-10, 10, -10), vec3.fromValues(10, 0, -10)],
+    });
     const glowLights = [
       new Light(gl, {
         positions: [

--- a/src/light.ts
+++ b/src/light.ts
@@ -66,6 +66,7 @@ export class Light {
       this.matrix.projection
     );
 
+    gl.uniform1f(locations.getUniform("radius"), this.radius);
     gl.uniform3fv(locations.getUniform("color"), this.color);
 
     gl.drawArrays(gl.TRIANGLE_FAN, 0, this.vertices.length);

--- a/src/light.ts
+++ b/src/light.ts
@@ -1,4 +1,4 @@
-import { mat4, vec3 } from "gl-matrix";
+import { vec3 } from "gl-matrix";
 import Matrix from "./matrix";
 import { ShaderLocations } from "./shaders/shader_locations";
 
@@ -21,27 +21,20 @@ export class Light {
 
   readonly matrix: Matrix;
 
-  readonly vertices: number[];
-
-  readonly verticesBuffer: WebGLBuffer | null;
+  private verticesBuffer: WebGLBuffer | null;
 
   constructor(gl: WebGL2RenderingContext, props: LightProps) {
     this.position = props.position;
     this.color = props.color ?? vec3.fromValues(1, 1, 1);
     this.power = props.power ?? 1;
     this.radius = props.radius ?? 1;
-    this.matrix = new Matrix(
-      gl,
-      mat4.fromTranslation(mat4.create(), this.position)
-    );
-
-    this.vertices = [...this.position];
+    this.matrix = new Matrix(gl);
 
     this.verticesBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, this.verticesBuffer);
     gl.bufferData(
       gl.ARRAY_BUFFER,
-      new Float32Array(this.vertices),
+      new Float32Array(this.position),
       gl.STATIC_DRAW
     );
   }
@@ -68,6 +61,6 @@ export class Light {
     gl.uniform1f(locations.getUniform("radius"), this.radius);
     gl.uniform3fv(locations.getUniform("color"), this.color);
 
-    gl.drawArrays(gl.POINTS, 0, this.vertices.length);
+    gl.drawArrays(gl.POINTS, 0, 1);
   }
 }

--- a/src/light.ts
+++ b/src/light.ts
@@ -1,4 +1,4 @@
-import { glMatrix, mat4, vec3 } from "gl-matrix";
+import { mat4, vec3 } from "gl-matrix";
 import Matrix from "./matrix";
 import { ShaderLocations } from "./shaders/shader_locations";
 
@@ -35,8 +35,7 @@ export class Light {
       mat4.fromTranslation(mat4.create(), this.position)
     );
 
-    const degrees = props.degrees ?? 20;
-    this.vertices = this.getVertices(degrees);
+    this.vertices = [...this.position];
 
     this.verticesBuffer = gl.createBuffer();
     gl.bindBuffer(gl.ARRAY_BUFFER, this.verticesBuffer);
@@ -51,7 +50,7 @@ export class Light {
     const vertexPosition = locations.getAttribute("vertexPosition");
     if (vertexPosition !== null) {
       gl.bindBuffer(gl.ARRAY_BUFFER, this.verticesBuffer);
-      gl.vertexAttribPointer(vertexPosition, 2, gl.FLOAT, false, 0, 0);
+      gl.vertexAttribPointer(vertexPosition, 3, gl.FLOAT, false, 0, 0);
       gl.enableVertexAttribArray(vertexPosition);
     }
 
@@ -69,20 +68,6 @@ export class Light {
     gl.uniform1f(locations.getUniform("radius"), this.radius);
     gl.uniform3fv(locations.getUniform("color"), this.color);
 
-    gl.drawArrays(gl.TRIANGLE_FAN, 0, this.vertices.length);
-  }
-
-  // Points on a circle are given by the equation (x, y) = (rsin(θ), rcos(θ)).
-  // (0, 0) is the center of the circle and is the shared vertex in the triangle fan.
-  private getVertices(degrees: number): number[] {
-    const vertices = [0, 0];
-    for (let d = 0; d <= 360; d += degrees) {
-      vertices.push(
-        this.radius * Math.sin(glMatrix.toRadian(d)),
-        this.radius * Math.cos(glMatrix.toRadian(d))
-      );
-    }
-
-    return vertices;
+    gl.drawArrays(gl.POINTS, 0, this.vertices.length);
   }
 }

--- a/src/light.ts
+++ b/src/light.ts
@@ -3,15 +3,14 @@ import Matrix from "./matrix";
 import { ShaderLocations } from "./shaders/shader_locations";
 
 export interface LightProps {
-  position: vec3;
+  positions: vec3[];
   color?: vec3;
   power?: number;
   radius?: number;
-  degrees?: number;
 }
 
 export class Light {
-  readonly position: vec3;
+  readonly positions: vec3[];
 
   readonly color: vec3;
 
@@ -24,7 +23,7 @@ export class Light {
   private verticesBuffer: WebGLBuffer | null;
 
   constructor(gl: WebGL2RenderingContext, props: LightProps) {
-    this.position = props.position;
+    this.positions = props.positions;
     this.color = props.color ?? vec3.fromValues(1, 1, 1);
     this.power = props.power ?? 1;
     this.radius = props.radius ?? 1;
@@ -34,7 +33,7 @@ export class Light {
     gl.bindBuffer(gl.ARRAY_BUFFER, this.verticesBuffer);
     gl.bufferData(
       gl.ARRAY_BUFFER,
-      new Float32Array(this.position),
+      new Float32Array(this.positions.flatMap((p) => [...p])),
       gl.STATIC_DRAW
     );
   }
@@ -61,6 +60,6 @@ export class Light {
     gl.uniform1f(locations.getUniform("radius"), this.radius);
     gl.uniform3fv(locations.getUniform("color"), this.color);
 
-    gl.drawArrays(gl.POINTS, 0, 1);
+    gl.drawArrays(gl.POINTS, 0, this.positions.length);
   }
 }

--- a/src/shaders/blinn_phong/shader.ts
+++ b/src/shaders/blinn_phong/shader.ts
@@ -48,7 +48,7 @@ export class BlinnPhongShader extends Shader<Model> {
         this.gl.uniform3fv(this.locations.getUniform('eye'), Matrix.EYE);
 
         this.lights.forEach((light, i) => {
-            this.gl.uniform3fv(this.locations.getUniform(`lights[${i}].position`), light.position);
+            this.gl.uniform3fv(this.locations.getUniform(`lights[${i}].position`), light.positions[0]);
             this.gl.uniform3fv(this.locations.getUniform(`lights[${i}].color`), light.color);
             this.gl.uniform1f(this.locations.getUniform(`lights[${i}].power`), light.power);
         });

--- a/src/shaders/crepuscular_ray/shader.ts
+++ b/src/shaders/crepuscular_ray/shader.ts
@@ -8,7 +8,6 @@ import { Light } from '../../light';
 
 export interface CrepuscularRayProps {
     colorTexture: WebGLTexture;
-    light: Light;
     samples: number;
     density: number;
     weight: number;
@@ -25,8 +24,7 @@ export class CrepuscularRay extends PostProcessing<RenderProps> {
     private props: CrepuscularRayProps;
     private occlusion: OcclusionShader;
     private postProcessing: PostProcessing;
-
-    readonly texture: WebGLTexture;
+    private texture: WebGLTexture;
 
     constructor(gl: WebGL2RenderingContext, props: CrepuscularRayProps) {
         super(gl, { vertexSrc, fragmentSrc });

--- a/src/shaders/crepuscular_ray/shader.ts
+++ b/src/shaders/crepuscular_ray/shader.ts
@@ -27,7 +27,7 @@ export class CrepuscularRay extends PostProcessing<RenderProps> {
     private texture: WebGLTexture;
 
     constructor(gl: WebGL2RenderingContext, props: CrepuscularRayProps) {
-        super(gl, { vertexSrc, fragmentSrc });
+        super(gl, vertexSrc, fragmentSrc);
 
         this.props = props;
         this.occlusion = new OcclusionShader(gl, { scale: 0.5 });
@@ -54,7 +54,6 @@ export class CrepuscularRay extends PostProcessing<RenderProps> {
 
         this.gl.uniformMatrix4fv(this.locations.getUniform('modelViewMatrix'), false, renderProps.light.matrix.modelView);
         this.gl.uniformMatrix4fv(this.locations.getUniform('projectionMatrix'), false, renderProps.light.matrix.projection);
-        this.gl.uniform3fv(this.locations.getUniform('lightPosition'), renderProps.light.positions[0]);
         this.gl.uniform1i(this.locations.getUniform('samples'), this.props.samples);
         this.gl.uniform1f(this.locations.getUniform('density'), this.props.density);
         this.gl.uniform1f(this.locations.getUniform('weight'), this.props.weight);
@@ -63,7 +62,11 @@ export class CrepuscularRay extends PostProcessing<RenderProps> {
 
         this.gl.framebufferTexture2D(this.gl.DRAW_FRAMEBUFFER, this.gl.COLOR_ATTACHMENT0, this.gl.TEXTURE_2D, this.texture, 0);
         this.gl.clear(this.gl.COLOR_BUFFER_BIT);
-        super.render(this.occlusion.texture);
+
+        renderProps.light.positions.forEach((position) => {
+            this.gl.uniform3fv(this.locations.getUniform('lightPosition'), position);
+            super.render(this.occlusion.texture);
+        });
 
         // Alpha-blend the crepuscular rays with the scene.
         this.gl.disable(this.gl.DEPTH_TEST);

--- a/src/shaders/crepuscular_ray/shader.ts
+++ b/src/shaders/crepuscular_ray/shader.ts
@@ -54,7 +54,7 @@ export class CrepuscularRay extends PostProcessing<RenderProps> {
 
         this.gl.uniformMatrix4fv(this.locations.getUniform('modelViewMatrix'), false, renderProps.light.matrix.modelView);
         this.gl.uniformMatrix4fv(this.locations.getUniform('projectionMatrix'), false, renderProps.light.matrix.projection);
-        this.gl.uniform3fv(this.locations.getUniform('lightPosition'), renderProps.light.position);
+        this.gl.uniform3fv(this.locations.getUniform('lightPosition'), renderProps.light.positions[0]);
         this.gl.uniform1i(this.locations.getUniform('samples'), this.props.samples);
         this.gl.uniform1f(this.locations.getUniform('density'), this.props.density);
         this.gl.uniform1f(this.locations.getUniform('weight'), this.props.weight);

--- a/src/shaders/crepuscular_ray/vertex.glsl
+++ b/src/shaders/crepuscular_ray/vertex.glsl
@@ -16,7 +16,7 @@ void main(void) {
     // Texture coordinates are in the range [0, 1].
     texturePosition = vertexPosition * 0.5 + 0.5;
 
-    // Normalized-device coordinates (NDC) are in the rante [-1, 1].
+    // Normalized-device coordinates (NDC) are in the range [-1, 1].
     vec4 lightPositionNDC = projectionMatrix * modelViewMatrix * vec4(lightPosition, 1);
     lightPositionNDC /= lightPositionNDC.w;
 

--- a/src/shaders/crepuscular_ray/vertex.glsl
+++ b/src/shaders/crepuscular_ray/vertex.glsl
@@ -1,13 +1,13 @@
 #version 300 es
 
 in vec2 vertexPosition;
-in vec3 lightPosition;
 
 out highp vec2 texturePosition;
 out highp vec2 lightRay;
 
 uniform mat4 modelViewMatrix;
 uniform mat4 projectionMatrix;
+uniform vec3 lightPosition;
 
 void main(void) {
     // gl_Position coordinates are in the range [-1, 1].

--- a/src/shaders/fxaa/shader.ts
+++ b/src/shaders/fxaa/shader.ts
@@ -4,7 +4,7 @@ import { PostProcessing } from '../post_processing/shader';
 export class FXAA extends PostProcessing {
 
     constructor(gl: WebGL2RenderingContext) {
-        super(gl, { fragmentSrc });
+        super(gl, undefined, fragmentSrc);
     }
 
     render(texture: WebGLTexture) {

--- a/src/shaders/glow/fragment.glsl
+++ b/src/shaders/glow/fragment.glsl
@@ -1,0 +1,19 @@
+#version 300 es
+
+precision highp float;
+
+in vec2 fragCenter;
+in float fragDepth;
+
+out vec4 fragColor;
+
+uniform float radius;
+uniform vec3 color;
+
+void main(void) {
+    gl_FragDepth = fragDepth;
+
+    float dist = distance(gl_FragCoord.xy, fragCenter);
+    float falloff = 20.0 * radius * clamp(0.0, 1.0 / dist, 1.0);
+    fragColor = vec4(color,1.0) * falloff;
+}

--- a/src/shaders/glow/fragment.glsl
+++ b/src/shaders/glow/fragment.glsl
@@ -7,15 +7,16 @@ in float fragDepth;
 out vec4 fragColor;
 
 uniform vec3 color;
-uniform float radius;
 
 void main(void) {
     gl_FragDepth = fragDepth;
 
     float dist = distance(gl_PointCoord, vec2(0.5, 0.5));
-    float falloff = 1.0 - clamp(dist, 0.0, 1.0);
-    vec4 innerColor = vec4(1.0) * pow(falloff, dist * radius);
-    vec4 outerColor = vec4(color, 1.0) * falloff;
-    // fragColor = vec4(innerColor + outerColor, falloff);
-    fragColor = innerColor;
+    float falloff = 1.0 - smoothstep(0.0, 0.5, dist);
+    float alpha = pow(falloff, dist);
+
+    vec4 innerColor = vec4(1, 1, 1, alpha);
+    vec4 outerColor = vec4(color, alpha);
+
+    fragColor = mix(outerColor, innerColor, falloff);
 }

--- a/src/shaders/glow/fragment.glsl
+++ b/src/shaders/glow/fragment.glsl
@@ -2,18 +2,20 @@
 
 precision highp float;
 
-in vec2 fragCenter;
 in float fragDepth;
 
 out vec4 fragColor;
 
-uniform float radius;
 uniform vec3 color;
+uniform float radius;
 
 void main(void) {
     gl_FragDepth = fragDepth;
 
-    float dist = distance(gl_FragCoord.xy, fragCenter);
-    float falloff = 20.0 * radius * clamp(0.0, 1.0 / dist, 1.0);
-    fragColor = vec4(color,1.0) * falloff;
+    float dist = distance(gl_PointCoord, vec2(0.5, 0.5));
+    float falloff = 1.0 - clamp(dist, 0.0, 1.0);
+    vec3 innerColor = vec3(color) * falloff * falloff;
+    // vec3 outerColor = vec3(1.0, 1.0, 1.0) * falloff;
+    // fragColor = vec4(innerColor + outerColor, falloff);
+    fragColor = vec4(innerColor, falloff);
 }

--- a/src/shaders/glow/fragment.glsl
+++ b/src/shaders/glow/fragment.glsl
@@ -14,8 +14,8 @@ void main(void) {
 
     float dist = distance(gl_PointCoord, vec2(0.5, 0.5));
     float falloff = 1.0 - clamp(dist, 0.0, 1.0);
-    vec3 innerColor = vec3(color) * falloff * falloff;
-    // vec3 outerColor = vec3(1.0, 1.0, 1.0) * falloff;
+    vec4 innerColor = vec4(1.0) * pow(falloff, dist * radius);
+    vec4 outerColor = vec4(color, 1.0) * falloff;
     // fragColor = vec4(innerColor + outerColor, falloff);
-    fragColor = vec4(innerColor, falloff);
+    fragColor = innerColor;
 }

--- a/src/shaders/glow/shader.ts
+++ b/src/shaders/glow/shader.ts
@@ -1,0 +1,31 @@
+import fragmentSrc from './fragment.glsl';
+import vertexSrc from './vertex.glsl';
+import { Light } from '../../light';
+import { Shader } from '../shader';
+import { vec2 } from 'gl-matrix';
+
+export class Glow extends Shader<Light> {
+
+    constructor(gl: WebGL2RenderingContext) {
+        super(gl, vertexSrc, fragmentSrc);
+
+        this.locations.setAttribute('vertexPosition');
+        this.locations.setUniform('modelViewMatrix');
+        this.locations.setUniform('projectionMatrix');
+        this.locations.setUniform('resolution');
+
+        this.locations.setUniform('radius');
+        this.locations.setUniform('color');
+    }
+
+    render(drawFramebuffer: WebGLFramebuffer, ...lights: Light[]) {
+        super.render(drawFramebuffer, ...lights);
+
+        this.gl.bindFramebuffer(this.gl.DRAW_FRAMEBUFFER, drawFramebuffer);
+
+        const resolution = vec2.fromValues(this.gl.drawingBufferWidth, this.gl.drawingBufferHeight);
+        this.gl.uniform2fv(this.locations.getUniform('resolution'), resolution);
+
+       lights?.forEach((l) => l.render(this.gl, this.locations));
+    }
+}

--- a/src/shaders/glow/shader.ts
+++ b/src/shaders/glow/shader.ts
@@ -2,7 +2,6 @@ import fragmentSrc from './fragment.glsl';
 import vertexSrc from './vertex.glsl';
 import { Light } from '../../light';
 import { Shader } from '../shader';
-import { vec2 } from 'gl-matrix';
 
 export class Glow extends Shader<Light> {
 
@@ -12,7 +11,6 @@ export class Glow extends Shader<Light> {
         this.locations.setAttribute('vertexPosition');
         this.locations.setUniform('modelViewMatrix');
         this.locations.setUniform('projectionMatrix');
-        this.locations.setUniform('resolution');
 
         this.locations.setUniform('radius');
         this.locations.setUniform('color');
@@ -23,9 +21,6 @@ export class Glow extends Shader<Light> {
 
         this.gl.bindFramebuffer(this.gl.DRAW_FRAMEBUFFER, drawFramebuffer);
 
-        const resolution = vec2.fromValues(this.gl.drawingBufferWidth, this.gl.drawingBufferHeight);
-        this.gl.uniform2fv(this.locations.getUniform('resolution'), resolution);
-
-       lights?.forEach((l) => l.render(this.gl, this.locations));
+        lights?.forEach((l) => l.render(this.gl, this.locations));
     }
 }

--- a/src/shaders/glow/vertex.glsl
+++ b/src/shaders/glow/vertex.glsl
@@ -1,0 +1,17 @@
+#version 300 es
+
+in vec4 vertexPosition;
+
+out highp float fragDepth;
+
+uniform mat4 modelViewMatrix;
+uniform mat4 projectionMatrix;
+uniform float radius;
+
+void main(void) {
+    gl_Position = projectionMatrix * modelViewMatrix * vertexPosition;
+
+    fragDepth = gl_Position.z / gl_Position.w;
+
+    gl_PointSize = radius;
+}

--- a/src/shaders/post_processing/shader.ts
+++ b/src/shaders/post_processing/shader.ts
@@ -21,8 +21,8 @@ export class PostProcessing<T = void> extends Shader<T> {
 
     private verticesBuffer: WebGLBuffer | null;
 
-    constructor(gl: WebGL2RenderingContext, props?: PostProcessingProps) {
-        super(gl, props?.vertexSrc ?? vertexSrc, props?.fragmentSrc ?? fragmentSrc);
+    constructor(gl: WebGL2RenderingContext, _vertexSrc?: string, _fragmentSrc?: string) {
+        super(gl, _vertexSrc ?? vertexSrc, _fragmentSrc ?? fragmentSrc);
 
         this.locations.setAttribute('vertexPosition');
         this.locations.setUniform('textureImage');


### PR DESCRIPTION
A light can have multiple positions. Each position corresponds to a vertex that will be rendered as a point. The glow shader renders the point as a circle with a colored edge that falls off. In this way, lights can be rendered as glowing orbs.

The crepuscular ray shader has been updated to make use of multiple light positions and now casts a ray for each light position.

![image](https://user-images.githubusercontent.com/1168893/221769967-3ad2e389-ee15-4f0b-a840-cd0dd1b17436.png)


