### PR TITLE
Fix controls

### DIFF
--- a/src/controls.ts
+++ b/src/controls.ts
@@ -39,11 +39,10 @@ const Controls = (canvas: JQuery<HTMLCanvasElement>) => {
     mousePosition = currentMousePosition;
 
     const [x, y] = mouseMovement;
-    const axis = vec3.normalize(vec3.create(), vec3.fromValues(y, x, 0));
-
+    const axis = vec3.normalize(vec3.create(), vec3.fromValues(-y, -x, 0));
     const angle = vec2.length(mouseMovement) / elapsedTimestamp;
 
-    Matrix.rotateView(angle, axis);
+    Matrix.rotateView(axis, angle);
   });
 
   canvas.on("mouseup", (event) => {

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -2,6 +2,8 @@ import { glMatrix, vec2, vec3 } from "gl-matrix";
 import Matrix from "./matrix";
 
 const Controls = (canvas: JQuery<HTMLCanvasElement>) => {
+    const LEFT_MOUSE = 0;
+
   let mousePosition: vec2 | undefined;
 
   let mouseMoveTimestamp: DOMHighResTimeStamp | undefined;
@@ -9,11 +11,15 @@ const Controls = (canvas: JQuery<HTMLCanvasElement>) => {
   let wheelTimestamp: DOMHighResTimeStamp | undefined;
 
   canvas.on("mousedown", (event) => {
+    if (event.button !== LEFT_MOUSE) {
+        return;
+    }
+
     mousePosition = vec2.fromValues(event.pageX, event.pageY);
   });
 
   canvas.on("mousemove", (event) => {
-    if (!mousePosition) {
+    if (event.button !== LEFT_MOUSE || !mousePosition) {
       return;
     }
 
@@ -44,7 +50,11 @@ const Controls = (canvas: JQuery<HTMLCanvasElement>) => {
     }
   });
 
-  canvas.on("mouseup", () => {
+  canvas.on("mouseup", (event) => {
+    if (event.button !== LEFT_MOUSE) {
+        return;
+    }
+
     mousePosition = undefined;
   });
 

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -39,7 +39,7 @@ const Controls = (canvas: JQuery<HTMLCanvasElement>) => {
     );
     axis = vec2.normalize(axis, axis);
 
-    const rotationAxis = vec3.fromValues(axis[0], -axis[1], 0);
+    const rotationAxis = vec3.fromValues(-axis[0], axis[1], 0);
 
     if (mouseMoveTimestamp !== event.timeStamp) {
       const elapsedTimestamp = event.timeStamp - (mouseMoveTimestamp ?? 0);

--- a/src/controls.ts
+++ b/src/controls.ts
@@ -2,7 +2,7 @@ import { glMatrix, vec2, vec3 } from "gl-matrix";
 import Matrix from "./matrix";
 
 const Controls = (canvas: JQuery<HTMLCanvasElement>) => {
-    const LEFT_MOUSE = 0;
+  const LEFT_MOUSE = 0;
 
   let mousePosition: vec2 | undefined;
 
@@ -12,16 +12,23 @@ const Controls = (canvas: JQuery<HTMLCanvasElement>) => {
 
   canvas.on("mousedown", (event) => {
     if (event.button !== LEFT_MOUSE) {
-        return;
+      return;
     }
 
     mousePosition = vec2.fromValues(event.pageX, event.pageY);
   });
 
   canvas.on("mousemove", (event) => {
-    if (event.button !== LEFT_MOUSE || !mousePosition) {
+    if (
+      event.button !== LEFT_MOUSE ||
+      !mousePosition ||
+      mouseMoveTimestamp === event.timeStamp
+    ) {
       return;
     }
+
+    const elapsedTimestamp = event.timeStamp - (mouseMoveTimestamp ?? 0);
+    mouseMoveTimestamp = event.timeStamp;
 
     const currentMousePosition = vec2.fromValues(event.pageX, event.pageY);
     const mouseMovement = vec2.subtract(
@@ -31,28 +38,17 @@ const Controls = (canvas: JQuery<HTMLCanvasElement>) => {
     );
     mousePosition = currentMousePosition;
 
-    let axis = vec2.rotate(
-      vec2.create(),
-      mouseMovement,
-      vec2.create(),
-      glMatrix.toRadian(90)
-    );
-    axis = vec2.normalize(axis, axis);
+    const [x, y] = mouseMovement;
+    const axis = vec3.normalize(vec3.create(), vec3.fromValues(y, x, 0));
 
-    const rotationAxis = vec3.fromValues(-axis[0], axis[1], 0);
+    const angle = vec2.length(mouseMovement) / elapsedTimestamp;
 
-    if (mouseMoveTimestamp !== event.timeStamp) {
-      const elapsedTimestamp = event.timeStamp - (mouseMoveTimestamp ?? 0);
-      mouseMoveTimestamp = event.timeStamp;
-
-      const angle = vec2.length(mouseMovement) / elapsedTimestamp;
-      Matrix.rotateView(angle, rotationAxis);
-    }
+    Matrix.rotateView(angle, axis);
   });
 
   canvas.on("mouseup", (event) => {
     if (event.button !== LEFT_MOUSE) {
-        return;
+      return;
     }
 
     mousePosition = undefined;

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -1,8 +1,6 @@
-import { vec3, glMatrix, mat4 } from "gl-matrix";
+import { vec3, glMatrix, mat4, quat } from "gl-matrix";
 
 class Matrix {
-  static readonly EYE = vec3.fromValues(0, 0, 10);
-
   private static MINIMUM_FOV = glMatrix.toRadian(60);
 
   private static MAXIMUM_FOV = glMatrix.toRadian(120);
@@ -16,6 +14,8 @@ class Matrix {
   private static CENTER = vec3.fromValues(0, 0, 0);
 
   private static UP = vec3.fromValues(0, 1, 0);
+
+  private static EYE = vec3.fromValues(0, 0, 10);
 
   private static projectionMatrix: mat4 | null;
 
@@ -52,13 +52,15 @@ class Matrix {
     return mat4.multiply(mat4.create(), Matrix.view(), model ?? mat4.create());
   }
 
-  static rotateView(angle: number, axis: vec3) {
-    Matrix.viewMatrix = mat4.rotate(
-      mat4.create(),
-      Matrix.view(),
-      glMatrix.toRadian(angle),
-      axis
-    );
+  static eye() {
+    return Matrix.EYE;
+  }
+
+  static rotateView(axis: vec3, angle: number) {
+    const q = quat.setAxisAngle(quat.create(), axis, glMatrix.toRadian(angle));
+    Matrix.EYE = vec3.transformQuat(Matrix.EYE, Matrix.EYE, q);
+
+    Matrix.viewMatrix = null;
   }
 
   static zoom(delta: number) {

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -1,7 +1,7 @@
 import { vec3, glMatrix, mat4 } from "gl-matrix";
 
 class Matrix {
-  static EYE = vec3.fromValues(0, 0, 10);
+  static readonly EYE = vec3.fromValues(0, 0, 10);
 
   private static MINIMUM_FOV = glMatrix.toRadian(60);
 

--- a/src/shaders/transparent/shader.ts
+++ b/src/shaders/transparent/shader.ts
@@ -56,7 +56,7 @@ export class TransparentShader extends Shader<Model> {
     render(timestamp: DOMHighResTimeStamp, drawFramebuffer: WebGLFramebuffer, ...models: Model[]) {
         super.render(timestamp, drawFramebuffer, ...models);
 
-        this.gl.uniform3fv(this.locations.getUniform('eye'), Matrix.EYE);
+        this.gl.uniform3fv(this.locations.getUniform('eye'), Matrix.eye());
         this.gl.uniform3fv(this.locations.getUniform('fresnelColor'), this.props.fresnelColor);
         this.gl.uniform1f(this.locations.getUniform('fresnelHueShift'), this.props.fresnelHueShift);
         this.gl.uniform1f(this.locations.getUniform('fresnelExponent'), this.props.fresnelExponent);

--- a/src/shaders/transparent/vertex.glsl
+++ b/src/shaders/transparent/vertex.glsl
@@ -12,5 +12,5 @@ uniform mat4 projectionMatrix;
 void main() {
     gl_Position = projectionMatrix * modelViewMatrix * vertexPosition;
     fragDepth = gl_Position.z / gl_Position.w;
-    fragNormal = (modelViewMatrix * vec4(normal, 0)).xyz;
+    fragNormal = normal;
 }


### PR DESCRIPTION
https://github.com/tinnywang/galaxy-brain/pull/21 implemented camera rotations by rotating the view matrix. This could cause a model to appear to rotate around an axis different from the expected one, creating unintuitive controls.

To fix this, rotate the eye vector instead of the view matrix. The view matrix uses the updated eye vector.
This change makes multiplying the eye vector by the view matrix unnecessary in shaders.

This PR also restricts rotation controls to left mouse events.