### PR TITLE
Fix controls with orientation quaternion

### DIFF
--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -57,10 +57,18 @@ class Matrix {
   }
 
   static rotateView(axis: vec3, angle: number) {
-    const q = quat.setAxisAngle(quat.create(), axis, glMatrix.toRadian(angle));
+    const q = quat.setAxisAngle(
+      quat.create(),
+      vec3.normalize(axis, axis),
+      glMatrix.toRadian(angle)
+    );
+
     Matrix.EYE = vec3.transformQuat(Matrix.EYE, Matrix.EYE, q);
+    Matrix.UP = vec3.transformQuat(Matrix.UP, Matrix.UP, q);
 
     Matrix.viewMatrix = null;
+
+    return q;
   }
 
   static zoom(delta: number) {

--- a/src/matrix.ts
+++ b/src/matrix.ts
@@ -52,10 +52,6 @@ class Matrix {
     return mat4.multiply(mat4.create(), Matrix.view(), model ?? mat4.create());
   }
 
-  static eye() {
-    return Matrix.EYE;
-  }
-
   static rotateView(axis: vec3, angle: number) {
     const q = quat.setAxisAngle(
       quat.create(),

--- a/src/shaders/transparent/fragment.glsl
+++ b/src/shaders/transparent/fragment.glsl
@@ -13,10 +13,11 @@ uniform highp vec3 color;
 uniform bool shouldDepthPeel;
 
 // Uniforms for Fresnel effect outline.
-uniform highp vec3 eye;
 uniform highp vec3 fresnelColor;
 uniform float fresnelHueShift;
 uniform float fresnelExponent;
+
+const vec3 Z_AXIS = vec3(0, 0, 1);
 
 // Shift the hue of an RGB color.
 // https://gist.github.com/mairod/a75e7b44f68110e1576d77419d608786?permalink_comment_id=3195243#gistcomment-3195243
@@ -40,7 +41,7 @@ void main() {
     } else if (opaqueDepth < gl_FragDepth) {
         discard;
     } else {
-        float dotProduct = abs(dot(normalize(fragNormal), normalize(eye)));
+        float dotProduct = abs(dot(normalize(fragNormal), Z_AXIS));
 
         float fresnel = smoothstep(0.0, 1.0, pow(1.0 - dotProduct, fresnelExponent));
         vec3 gradientColor = hueShift(color, fresnelHueShift);

--- a/src/shaders/transparent/shader.ts
+++ b/src/shaders/transparent/shader.ts
@@ -4,7 +4,6 @@ import { Shader } from '../shader';
 import { PostProcessing } from '../post_processing/shader';
 import { Model } from '../../models/model';
 import WebGL2 from '../../gl';
-import Matrix from '../../matrix';
 import { vec3 } from 'gl-matrix';
 import { Face } from '../../object';
 
@@ -56,7 +55,6 @@ export class TransparentShader extends Shader<Model> {
     render(timestamp: DOMHighResTimeStamp, drawFramebuffer: WebGLFramebuffer, ...models: Model[]) {
         super.render(timestamp, drawFramebuffer, ...models);
 
-        this.gl.uniform3fv(this.locations.getUniform('eye'), Matrix.eye());
         this.gl.uniform3fv(this.locations.getUniform('fresnelColor'), this.props.fresnelColor);
         this.gl.uniform1f(this.locations.getUniform('fresnelHueShift'), this.props.fresnelHueShift);
         this.gl.uniform1f(this.locations.getUniform('fresnelExponent'), this.props.fresnelExponent);

--- a/src/shaders/transparent/vertex.glsl
+++ b/src/shaders/transparent/vertex.glsl
@@ -12,5 +12,5 @@ uniform mat4 projectionMatrix;
 void main() {
     gl_Position = projectionMatrix * modelViewMatrix * vertexPosition;
     fragDepth = gl_Position.z / gl_Position.w;
-    fragNormal = normal;
+    fragNormal = (modelViewMatrix * vec4(normal, 0)).xyz;
 }


### PR DESCRIPTION
The controls from https://github.com/tinnywang/galaxy-brain/pull/23 sometimes rotate the camera around the wrong axis. This is because the mouse coordinates / rotation axis weren't being transformed into the camera's rotated coordinate system. We now maintain an orientation quaternion for this purpose.