### PR TITLE
Fade animations work with lights

### DIFF
--- a/src/animations/animation.ts
+++ b/src/animations/animation.ts
@@ -1,7 +1,5 @@
-import { Model } from "../models/model";
-
-export abstract class Animation {
-    protected readonly model: Model;
+export abstract class Animation<T> {
+    protected readonly model: T;
 
     protected readonly duration: DOMHighResTimeStamp;
 
@@ -11,7 +9,7 @@ export abstract class Animation {
 
     private requestID: number;
 
-    constructor(model: Model, duration: DOMHighResTimeStamp) {
+    constructor(model: T, duration: DOMHighResTimeStamp) {
         this.model = model;
         this.duration = duration;
 

--- a/src/animations/fade.ts
+++ b/src/animations/fade.ts
@@ -1,10 +1,11 @@
+import { Light } from "../light";
 import { Model } from "../models/model";
 import { Animation } from "./animation";
 
-abstract class Fade extends Animation {
+abstract class Fade extends Animation<Model | Light> {
     private delta: number;
 
-    constructor(model: Model, alphaDelta: number, duration: DOMHighResTimeStamp) {
+    constructor(model: Model | Light, alphaDelta: number, duration: DOMHighResTimeStamp) {
         super(model, duration);
 
         this.delta = alphaDelta / this.duration;
@@ -21,7 +22,7 @@ abstract class Fade extends Animation {
 }
 
 export class FadeIn extends Fade {
-    constructor(model: Model, duration: DOMHighResTimeStamp) {
+    constructor(model: Model | Light, duration: DOMHighResTimeStamp) {
         super(model, 1 - model.alpha, duration);
     }
 
@@ -32,7 +33,7 @@ export class FadeIn extends Fade {
 }
 
 export class FadeOut extends Fade {
-    constructor(model: Model, duration: DOMHighResTimeStamp) {
+    constructor(model: Model | Light, duration: DOMHighResTimeStamp) {
         super(model, -model.alpha, duration);
     }
 

--- a/src/animations/scale.ts
+++ b/src/animations/scale.ts
@@ -1,7 +1,7 @@
 import { Model } from "../models/model";
 import { Animation } from "./animation";
 
-export class Scale extends Animation {
+export class Scale extends Animation<Model> {
     private readonly scale: number;
 
     private readonly delta: number;

--- a/src/galaxy_brain.ts
+++ b/src/galaxy_brain.ts
@@ -11,6 +11,7 @@ import { CrepuscularRay } from "./shaders/crepuscular_ray/shader";
 import { Animation } from "./animations/animation";
 import { FadeIn, FadeOut } from "./animations/fade";
 import { Scale } from "./animations/scale";
+import { Model } from "./models/model";
 
 interface Shaders {
   transparent: TransparentShader;
@@ -34,7 +35,7 @@ class GalaxyBrain {
 
   private stage = 0;
 
-  private animations: Animation[] = [];
+  private animations: Animation<Model | Light>[] = [];
 
   constructor(gl: WebGL2RenderingContext, shaders: Shaders) {
     this.shaders = shaders;

--- a/src/galaxy_brain.ts
+++ b/src/galaxy_brain.ts
@@ -47,10 +47,6 @@ class GalaxyBrain {
       center
     );
 
-    this.light = new Light(gl, {
-      positions: [center],
-    });
-
     this.head = new Head(gl, model);
     this.head.alpha = 0;
 
@@ -58,13 +54,20 @@ class GalaxyBrain {
 
     this.brain = new Brain(gl, model);
     this.brain.scale(0.5);
+    this.brain.neurons.alpha = 0;
 
     this.lasers = new Laser(gl, model);
+    this.lasers.stars.alpha = 0;
+
+    this.light = new Light(gl, {
+      positions: [center],
+    });
+    this.light.alpha = 0;
   }
 
   render(timestamp: DOMHighResTimeStamp, framebuffer: WebGLFramebuffer) {
     // Render the laser beams behind the stars.
-    // this.shaders.star.render(timestamp, framebuffer, this.lasers.stars);
+    this.shaders.star.render(timestamp, framebuffer, this.lasers.stars);
 
     this.shaders.transparent.render(
       timestamp,
@@ -74,14 +77,12 @@ class GalaxyBrain {
       this.brain
     );
 
-    /*
     this.shaders.crepuscularRay.render(timestamp, framebuffer, {
       models: this.lasers.beams,
       light: this.light,
     });
 
     this.shaders.glow.render(timestamp, framebuffer, this.brain.neurons);
-    */
   }
 
   evolve(stage: number) {
@@ -93,7 +94,10 @@ class GalaxyBrain {
         this.animations.push(
           new Scale(this.brain, 0.5, 500),
           new FadeIn(this.skull, 2500),
-          new FadeOut(this.head, 2500)
+          new FadeOut(this.head, 2500),
+          new FadeOut(this.brain.neurons, 2500),
+          new FadeOut(this.lasers.stars, 2500),
+          new FadeOut(this.light, 1000),
         );
         break;
       default:
@@ -101,7 +105,10 @@ class GalaxyBrain {
           this.animations.push(
             new Scale(this.brain, 1 / this.brain.getScale(), 500),
             new FadeIn(this.head, 2500),
-            new FadeOut(this.skull, 2500)
+            new FadeIn(this.brain.neurons, 2500),
+            new FadeOut(this.skull, 2500),
+            new FadeIn(this.lasers.stars, 2500),
+            new FadeIn(this.light, 1000),
           );
         }
     }

--- a/src/light.ts
+++ b/src/light.ts
@@ -23,6 +23,8 @@ export class Light {
 
   private verticesBuffer: WebGLBuffer | null;
 
+  alpha = 1;
+
   constructor(gl: WebGL2RenderingContext, props: LightProps) {
     this.positions = props.positions;
     this.color = props.color ?? vec3.fromValues(1, 1, 1);
@@ -40,6 +42,10 @@ export class Light {
   }
 
   render(gl: WebGL2RenderingContext, locations: ShaderLocations) {
+    if (this.alpha === 0) {
+      return;
+    }
+
     const vertexPosition = locations.getAttribute("vertexPosition");
     if (vertexPosition !== null) {
       gl.bindBuffer(gl.ARRAY_BUFFER, this.verticesBuffer);
@@ -59,7 +65,7 @@ export class Light {
     );
 
     gl.uniform1f(locations.getUniform("radius"), this.radius);
-    gl.uniform3fv(locations.getUniform("color"), this.color);
+    gl.uniform4fv(locations.getUniform("color"), [...this.color, this.alpha]);
 
     gl.drawArrays(gl.POINTS, 0, this.positions.length);
   }

--- a/src/shaders/crepuscular_ray/fragment.glsl
+++ b/src/shaders/crepuscular_ray/fragment.glsl
@@ -11,13 +11,14 @@ uniform sampler2D textureImage;
 uniform int samples;
 uniform float density;
 uniform float weight;
+uniform float alpha;
 uniform float decay;
 uniform float exposure;
 
 void main(void) {
     vec2 delta = lightRay / float(samples) * density;
     vec2 samplePosition = texturePosition;
-    float illuminationDecay = 1.0;
+    float illuminationDecay = alpha;
     fragColor = texture(textureImage, texturePosition);
 
     for (int i = 0; i < samples; i++) {

--- a/src/shaders/crepuscular_ray/shader.ts
+++ b/src/shaders/crepuscular_ray/shader.ts
@@ -41,12 +41,17 @@ export class CrepuscularRay extends PostProcessing<RenderProps> {
         this.locations.setUniform('samples');
         this.locations.setUniform('density');
         this.locations.setUniform('weight');
+        this.locations.setUniform('alpha');
         this.locations.setUniform('decay');
         this.locations.setUniform('exposure');
         this.locations.setUniform('colorTexture');
     }
 
     render(timestamp: DOMHighResTimeStamp, drawFramebuffer: WebGLFramebuffer, renderProps: RenderProps) {
+        if (renderProps.light.alpha === 0) {
+            return;
+        }
+
         // Render occluding objects black and untextured.
         this.occlusion.render(timestamp, drawFramebuffer, ...renderProps.models);
 
@@ -58,6 +63,7 @@ export class CrepuscularRay extends PostProcessing<RenderProps> {
         this.gl.uniform1i(this.locations.getUniform('samples'), this.props.samples);
         this.gl.uniform1f(this.locations.getUniform('density'), this.props.density);
         this.gl.uniform1f(this.locations.getUniform('weight'), this.props.weight);
+        this.gl.uniform1f(this.locations.getUniform('alpha'), renderProps.light.alpha);
         this.gl.uniform1f(this.locations.getUniform('decay'), this.props.decay);
         this.gl.uniform1f(this.locations.getUniform('exposure'), this.props.exposure);
 

--- a/src/shaders/glow/fragment.glsl
+++ b/src/shaders/glow/fragment.glsl
@@ -4,7 +4,7 @@ precision highp float;
 
 out vec4 fragColor;
 
-uniform vec3 color;
+uniform vec4 color;
 uniform sampler2D lensFlareTexture;
 
 void main(void) {
@@ -12,7 +12,7 @@ void main(void) {
     dist = smoothstep(0.0, 0.5, dist);
 
     float alpha = texture(lensFlareTexture, gl_PointCoord).a;
-    vec3 gradient = mix(vec3(1), color, dist);
+    vec3 gradient = mix(vec3(1), color.rgb, dist);
 
-    fragColor = vec4(gradient, alpha);
+    fragColor = vec4(gradient, min(alpha, color.a));
 }

--- a/src/shaders/star/fragment.glsl
+++ b/src/shaders/star/fragment.glsl
@@ -6,7 +6,7 @@ in mat2 rotationMatrix;
 
 out vec4 fragColor;
 
-uniform vec3 color;
+uniform vec4 color;
 uniform sampler2D lensFlareTexture;
 
 const vec2 center = vec2(0.5);
@@ -20,7 +20,7 @@ void main(void) {
     textureCoord += center;
 
     float alpha = texture(lensFlareTexture, textureCoord).a;
-    vec3 gradient = mix(vec3(1), color, dist);
+    vec3 gradient = mix(vec3(1), color.rgb, dist);
 
-    fragColor = vec4(gradient, alpha);
+    fragColor = vec4(gradient.rgb, min(alpha, color.a));
 }


### PR DESCRIPTION
Lights can now fade-in and fade-out.
- Update the `FadeIn` and `FadeOut` animations to work with lights.
- Update shaders that subclass `LensFlare` to use the light's alpha value.
- Update the crepuscular ray shader to use the light's alpha value.