### PR TITLE
Refactor animations

### DIFF
--- a/src/animations/animation.ts
+++ b/src/animations/animation.ts
@@ -9,6 +9,8 @@ export abstract class Animation<T> {
 
     private requestID: number;
 
+    private static queue: Animation<any>[] = [];
+
     constructor(model: T, duration: DOMHighResTimeStamp) {
         this.model = model;
         this.duration = duration;
@@ -29,9 +31,17 @@ export abstract class Animation<T> {
         }
     }
 
-    cancel() {
+    private cancel() {
         cancelAnimationFrame(this.requestID);
     }
 
     abstract isDone(): boolean;
+
+    static run<T>(...animations: Animation<T>[]) {
+        // Cancel in-progress animations and clear the queue.
+        Animation.queue.forEach((a) => a.cancel());
+        Animation.queue = [];
+
+        Animation.queue.push(...animations);
+    }
 }

--- a/src/animations/animation.ts
+++ b/src/animations/animation.ts
@@ -1,6 +1,4 @@
-export abstract class Animation<T> {
-    protected readonly model: T;
-
+export abstract class Animation {
     protected readonly duration: DOMHighResTimeStamp;
 
     protected elapsedTimestamp: DOMHighResTimeStamp | undefined; 
@@ -9,10 +7,9 @@ export abstract class Animation<T> {
 
     private requestID: number;
 
-    private static queue: Animation<any>[] = [];
+    private static queue: Animation[] = [];
 
-    constructor(model: T, duration: DOMHighResTimeStamp) {
-        this.model = model;
+    constructor(duration: DOMHighResTimeStamp) {
         this.duration = duration;
 
         this.requestID = requestAnimationFrame(this.render.bind(this));
@@ -37,7 +34,7 @@ export abstract class Animation<T> {
 
     abstract isDone(): boolean;
 
-    static run<T>(...animations: Animation<T>[]) {
+    static run(...animations: Animation[]) {
         // Cancel in-progress animations and clear the queue.
         Animation.queue.forEach((a) => a.cancel());
         Animation.queue = [];

--- a/src/animations/fade.ts
+++ b/src/animations/fade.ts
@@ -1,17 +1,19 @@
-import { Light } from "../light";
-import { Model } from "../models/model";
 import { Animation } from "./animation";
 
+interface Fadeable {
+    alpha: number;
+}
+
 abstract class Fade extends Animation {
-    protected model: Model | Light;
+    protected object: Fadeable;
 
     private delta: number;
 
-    constructor(model: Model | Light, alphaDelta: number, duration: DOMHighResTimeStamp) {
+    constructor(object: Fadeable, delta: number, duration: DOMHighResTimeStamp) {
         super(duration);
 
-        this.model = model;
-        this.delta = alphaDelta / this.duration;
+        this.object = object;
+        this.delta = delta / this.duration;
     }
 
     render(timestamp: DOMHighResTimeStamp) {
@@ -19,29 +21,29 @@ abstract class Fade extends Animation {
 
         if (!this.isDone()) {
             const delta = this.elapsedTimestamp ? this.delta * this.elapsedTimestamp : 0;
-            this.model.alpha += delta;
+            this.object.alpha += delta;
         }
     }
 }
 
 export class FadeIn extends Fade {
-    constructor(model: Model | Light, duration: DOMHighResTimeStamp) {
-        super(model, 1 - model.alpha, duration);
+    constructor(object: Fadeable, duration: DOMHighResTimeStamp) {
+        super(object, 1 - object.alpha, duration);
     }
 
     isDone() {
-        this.model.alpha = Math.min(this.model.alpha, 1);
-        return this.model.alpha === 1;
+        this.object.alpha = Math.min(this.object.alpha, 1);
+        return this.object.alpha === 1;
     }
 }
 
 export class FadeOut extends Fade {
-    constructor(model: Model | Light, duration: DOMHighResTimeStamp) {
-        super(model, -model.alpha, duration);
+    constructor(object: Fadeable, duration: DOMHighResTimeStamp) {
+        super(object, -object.alpha, duration);
     }
 
     isDone() {
-        this.model.alpha = Math.max(this.model.alpha, 0);
-        return this.model.alpha === 0;
+        this.object.alpha = Math.max(this.object.alpha, 0);
+        return this.object.alpha === 0;
     }
 }

--- a/src/animations/fade.ts
+++ b/src/animations/fade.ts
@@ -2,12 +2,15 @@ import { Light } from "../light";
 import { Model } from "../models/model";
 import { Animation } from "./animation";
 
-abstract class Fade extends Animation<Model | Light> {
+abstract class Fade extends Animation {
+    protected model: Model | Light;
+
     private delta: number;
 
     constructor(model: Model | Light, alphaDelta: number, duration: DOMHighResTimeStamp) {
-        super(model, duration);
+        super(duration);
 
+        this.model = model;
         this.delta = alphaDelta / this.duration;
     }
 

--- a/src/animations/scale.ts
+++ b/src/animations/scale.ts
@@ -1,7 +1,9 @@
 import { Model } from "../models/model";
 import { Animation } from "./animation";
 
-export class Scale extends Animation<Model> {
+export class Scale extends Animation {
+    private readonly model: Model;
+
     private readonly scale: number;
 
     private readonly delta: number;
@@ -9,7 +11,9 @@ export class Scale extends Animation<Model> {
     private readonly scaleUp: boolean;
 
     constructor(model: Model, n: number, duration: DOMHighResTimeStamp) {
-        super(model, duration);
+        super(duration);
+
+        this.model = model;
 
         // If the model was previously scaled by 0.5 and is now being scaled by 2,
         // its final scale should be 0.5 * 2 = 1.

--- a/src/animations/scale.ts
+++ b/src/animations/scale.ts
@@ -1,8 +1,8 @@
-import { Model } from "../models/model";
+import { mat4, vec3 } from "gl-matrix";
 import { Animation } from "./animation";
 
 export class Scale extends Animation {
-    private readonly model: Model;
+    private readonly matrix: mat4;
 
     private readonly scale: number;
 
@@ -10,14 +10,14 @@ export class Scale extends Animation {
 
     private readonly scaleUp: boolean;
 
-    constructor(model: Model, n: number, duration: DOMHighResTimeStamp) {
+    constructor(matrix: mat4, n: number, duration: DOMHighResTimeStamp) {
         super(duration);
 
-        this.model = model;
+        this.matrix = matrix;
 
         // If the model was previously scaled by 0.5 and is now being scaled by 2,
         // its final scale should be 0.5 * 2 = 1.
-        const s = this.model.getScale();
+        const s = this.scaling();
         this.scale = s * n;
 
         this.delta = Math.abs(s - this.scale) / this.duration;
@@ -35,12 +35,17 @@ export class Scale extends Animation {
             if (!this.scaleUp) {
                 delta *= -1
             }
-            this.model.scale(1 + delta / this.model.getScale());
+            const s = 1 + delta / this.scaling();
+            mat4.scale(this.matrix, this.matrix, vec3.fromValues(s, s, s));
         }
     }
 
     isDone() {
-        const s = this.model.getScale();
+        const s = this.scaling();
         return this.scaleUp ? s >= this.scale : s <= this.scale;
+    }
+
+    private scaling() {
+        return mat4.getScaling(vec3.create(), this.matrix)[0];
     }
 }

--- a/src/galaxy_brain.ts
+++ b/src/galaxy_brain.ts
@@ -49,8 +49,7 @@ class GalaxyBrain {
 
     this.skull = new Skull(gl, model);
 
-    this.brain = new Brain(gl, model);
-    this.brain.scale(0.5);
+    this.brain = new Brain(gl, mat4.scale(mat4.create(), model, vec3.fromValues(0.5, 0.5, 0.5)));
     this.brain.neurons.alpha = 0;
 
     this.lasers = new Laser(gl, model);
@@ -86,7 +85,7 @@ class GalaxyBrain {
     switch (stage) {
       case 0:
         Animation.run(
-          new Scale(this.brain, 0.5, 500),
+          new Scale(this.brain.model, 0.5, 500),
           new FadeIn(this.skull, 2500),
           new FadeOut(this.head, 2500),
           new FadeOut(this.brain.neurons, 2500),
@@ -97,7 +96,7 @@ class GalaxyBrain {
       default:
         if (this.stage === 0) {
           Animation.run(
-            new Scale(this.brain, 1 / this.brain.getScale(), 500),
+            new Scale(this.brain.model, 2, 500),
             new FadeIn(this.head, 2500),
             new FadeIn(this.brain.neurons, 2500),
             new FadeOut(this.skull, 2500),

--- a/src/galaxy_brain.ts
+++ b/src/galaxy_brain.ts
@@ -49,7 +49,10 @@ class GalaxyBrain {
 
     this.skull = new Skull(gl, model);
 
-    this.brain = new Brain(gl, mat4.scale(mat4.create(), model, vec3.fromValues(0.5, 0.5, 0.5)));
+    this.brain = new Brain(
+      gl,
+      mat4.scale(mat4.create(), model, vec3.fromValues(0.5, 0.5, 0.5))
+    );
     this.brain.neurons.alpha = 0;
 
     this.lasers = new Laser(gl, model);
@@ -90,7 +93,7 @@ class GalaxyBrain {
           new FadeOut(this.head, 2500),
           new FadeOut(this.brain.neurons, 2500),
           new FadeOut(this.lasers.stars, 2500),
-          new FadeOut(this.light, 1000),
+          new FadeOut(this.light, 1000)
         );
         break;
       default:
@@ -101,7 +104,7 @@ class GalaxyBrain {
             new FadeIn(this.brain.neurons, 2500),
             new FadeOut(this.skull, 2500),
             new FadeIn(this.lasers.stars, 2500),
-            new FadeIn(this.light, 1000),
+            new FadeIn(this.light, 1000)
           );
         }
     }

--- a/src/galaxy_brain.ts
+++ b/src/galaxy_brain.ts
@@ -11,7 +11,6 @@ import { CrepuscularRay } from "./shaders/crepuscular_ray/shader";
 import { Animation } from "./animations/animation";
 import { FadeIn, FadeOut } from "./animations/fade";
 import { Scale } from "./animations/scale";
-import { Model } from "./models/model";
 
 interface Shaders {
   transparent: TransparentShader;
@@ -34,8 +33,6 @@ class GalaxyBrain {
   private readonly shaders: Shaders;
 
   private stage = 0;
-
-  private animations: Animation<Model | Light>[] = [];
 
   constructor(gl: WebGL2RenderingContext, shaders: Shaders) {
     this.shaders = shaders;
@@ -86,12 +83,9 @@ class GalaxyBrain {
   }
 
   evolve(stage: number) {
-    this.animations.forEach((a) => a.cancel());
-    this.animations = [];
-
     switch (stage) {
       case 0:
-        this.animations.push(
+        Animation.run(
           new Scale(this.brain, 0.5, 500),
           new FadeIn(this.skull, 2500),
           new FadeOut(this.head, 2500),
@@ -102,7 +96,7 @@ class GalaxyBrain {
         break;
       default:
         if (this.stage === 0) {
-          this.animations.push(
+          Animation.run(
             new Scale(this.brain, 1 / this.brain.getScale(), 500),
             new FadeIn(this.head, 2500),
             new FadeIn(this.brain.neurons, 2500),

--- a/src/models/model.ts
+++ b/src/models/model.ts
@@ -1,4 +1,4 @@
-import { mat4, vec3 } from "gl-matrix";
+import { mat4 } from "gl-matrix";
 import { Face, Object } from "../object";
 import Matrix from "../matrix";
 import { ShaderLocations } from "../shaders/shader_locations";
@@ -16,7 +16,7 @@ export abstract class Model {
 
   readonly object: Object;
 
-  private model: mat4;
+  readonly model: mat4;
 
   alpha = 1;
 
@@ -93,14 +93,5 @@ export abstract class Model {
       // Offset must be a multiple of 8 since an unsigned int is 8 bytes.
       offset += f.vertex_indices.length * 8;
     })
-  }
-
-  scale(n: number) {
-    this.model = mat4.scale(mat4.create(), this.model, vec3.fromValues(n, n, n));
-  }
-
-  getScale(): number {
-    const v = mat4.getScaling(vec3.create(), this.model);
-    return v[0]
   }
 }


### PR DESCRIPTION
- The `Animation` class now manages the queue of running animations.
- `Animation` no longer uses generics.
- `Scale` operates on a `mat4` instead of a `Model`.
- `Fade` operates on a `Fadeable` instead of `Model | Light`.