### PR TITLE
Use alpha mask with transparency shader

### DIFF
--- a/src/galaxy_brain.ts
+++ b/src/galaxy_brain.ts
@@ -12,8 +12,10 @@ import { Animation } from "./animations/animation";
 import { FadeIn, FadeOut } from "./animations/fade";
 import { Scale } from "./animations/scale";
 import { Rotation } from "./animations/rotation";
+import { AlphaMask } from "./shaders/alpha_mask/shader";
 
 interface Shaders {
+  alphaMask: AlphaMask;
   transparent: TransparentShader;
   crepuscularRay: CrepuscularRay;
   star: Star;
@@ -96,6 +98,7 @@ class GalaxyBrain {
       exposure: 0.0035,
     });
 
+    this.shaders.alphaMask.render(timestamp, framebuffer, this.brain);
     this.shaders.transparent.render(
       timestamp,
       framebuffer,

--- a/src/galaxy_brain.ts
+++ b/src/galaxy_brain.ts
@@ -100,15 +100,9 @@ class GalaxyBrain {
       timestamp,
       framebuffer,
       { model: this.head },
-      { model: this.skull, xray: true }
+      { model: this.skull, xray: true },
+      { model: this.brain, xray: true }
     );
-
-    // Render the brain separately from the other transparent objects so that it isn't occluded.
-    // This isn't technically or anatomically correct, but it is more aesthetically pleasing.
-    this.shaders.transparent.render(timestamp, framebuffer, {
-      model: this.brain,
-      xray: true,
-    });
 
     this.shaders.crepuscularRay.render(timestamp, framebuffer, {
       models: this.lasers.beams,
@@ -149,9 +143,7 @@ class GalaxyBrain {
       case 2:
         Animation.run(
           new Scale(this.brain.model, 1 / this.brain.scaling(), 500),
-          stage === 1
-            ? new FadeIn(this.brain.neurons, 1000)
-            : new FadeOut(this.brain.neurons, 1000),
+          new FadeIn(this.brain.neurons, 1000),
           ...this.lasers.beams.map((b) => new FadeOut(b, 1000)),
           new FadeOut(this.lasers.stars, 500),
           stage === 1

--- a/src/galaxy_brain.ts
+++ b/src/galaxy_brain.ts
@@ -99,10 +99,16 @@ class GalaxyBrain {
     this.shaders.transparent.render(
       timestamp,
       framebuffer,
-      this.head,
-      this.skull,
-      this.brain
+      { model: this.head },
+      { model: this.skull, xray: true }
     );
+
+    // Render the brain separately from the other transparent objects so that it isn't occluded.
+    // This isn't technically or anatomically correct, but it is more aesthetically pleasing.
+    this.shaders.transparent.render(timestamp, framebuffer, {
+      model: this.brain,
+      xray: true,
+    });
 
     this.shaders.crepuscularRay.render(timestamp, framebuffer, {
       models: this.lasers.beams,

--- a/src/index.ts
+++ b/src/index.ts
@@ -7,6 +7,7 @@ import { FXAA } from "./shaders/fxaa/shader";
 import { Glow } from "./shaders/glow/shader";
 import Controls from "./controls";
 import GalaxyBrain from "./galaxy_brain";
+import { AlphaMask } from "./shaders/alpha_mask/shader";
 import { Star } from "./shaders/star/shader";
 
 $(() => {
@@ -48,7 +49,9 @@ $(() => {
       0
     );
 
+    const alphaMask = new AlphaMask(gl, colorTexture);
     const transparent = new TransparentShader(gl, {
+      alphaMaskTexture: alphaMask.texture,
       opaqueDepthTexture: depthTexture,
       fresnelColor: vec3.fromValues(1, 1, 1),
       fresnelHueShift: -20,
@@ -59,6 +62,7 @@ $(() => {
     const glow = new Glow(gl);
     const fxaa = new FXAA(gl);
     const galaxyBrain = new GalaxyBrain(gl, {
+      alphaMask,
       transparent,
       crepuscularRay,
       star,

--- a/src/shaders/alpha_mask/fragment.glsl
+++ b/src/shaders/alpha_mask/fragment.glsl
@@ -1,0 +1,11 @@
+#version 300 es
+
+precision highp float;
+
+out vec4 fragColor;
+
+uniform float alpha;
+
+void main(void) {
+    fragColor = vec4(alpha);
+}

--- a/src/shaders/alpha_mask/shader.ts
+++ b/src/shaders/alpha_mask/shader.ts
@@ -1,0 +1,49 @@
+import fragmentSrc from './fragment.glsl';
+import vertexSrc from '../occlusion/vertex.glsl';
+import { Shader } from '../shader';
+import WebGL2 from '../../gl';
+import { Model } from '../../models/model';
+
+export class AlphaMask extends Shader<Model> {
+    readonly texture: WebGLTexture;
+
+    private colorTexture: WebGLTexture;
+
+    constructor(gl: WebGL2RenderingContext, colorTexture: WebGLTexture) {
+        super(gl, vertexSrc, fragmentSrc);
+
+        this.colorTexture = colorTexture;
+
+        this.texture = WebGL2.createColorTextures(
+            gl,
+            1,
+            gl.drawingBufferWidth,
+            gl.drawingBufferHeight,
+        )[0];
+
+        this.locations.setAttribute('vertexPosition');
+        this.locations.setUniform('modelViewMatrix');
+        this.locations.setUniform('projectionMatrix');
+        this.locations.setUniform('alpha');
+    }
+
+    render(timestamp: DOMHighResTimeStamp, drawFramebuffer: WebGLFramebuffer, ...models: Model[]) {
+        super.render(timestamp, drawFramebuffer, ...models);
+
+        this.gl.bindFramebuffer(this.gl.DRAW_FRAMEBUFFER, drawFramebuffer);
+        this.gl.framebufferTexture2D(this.gl.DRAW_FRAMEBUFFER, this.gl.COLOR_ATTACHMENT0, this.gl.TEXTURE_2D, this.texture, 0);
+        this.gl.framebufferTexture2D(this.gl.DRAW_FRAMEBUFFER, this.gl.DEPTH_ATTACHMENT, this.gl.TEXTURE_2D, null, 0);
+
+        this.gl.disable(this.gl.DEPTH_TEST);
+        this.gl.clear(this.gl.COLOR_BUFFER_BIT);
+
+        models?.forEach((m) => {
+            this.gl.uniform1f(this.locations.getUniform('alpha'), m.alpha);
+            m.render(this.gl, this.locations)
+        });
+
+        this.gl.bindFramebuffer(this.gl.DRAW_FRAMEBUFFER, drawFramebuffer);
+        this.gl.framebufferTexture2D(this.gl.DRAW_FRAMEBUFFER, this.gl.COLOR_ATTACHMENT0, this.gl.TEXTURE_2D, this.colorTexture, 0);
+        this.gl.framebufferTexture2D(this.gl.DRAW_FRAMEBUFFER, this.gl.DEPTH_ATTACHMENT, this.gl.TEXTURE_2D, null, 0);
+    }
+}

--- a/src/shaders/crepuscular_ray/shader.ts
+++ b/src/shaders/crepuscular_ray/shader.ts
@@ -7,7 +7,7 @@ import WebGL2 from '../../gl';
 import { Light } from '../../light';
 import Matrix from '../../matrix';
 
-export interface RenderProps {
+interface RenderProps {
     models: Model[];
     light: Light;
     samples: number;

--- a/src/shaders/transparent/fragment.glsl
+++ b/src/shaders/transparent/fragment.glsl
@@ -16,6 +16,7 @@ uniform bool shouldDepthPeel;
 uniform highp vec3 fresnelColor;
 uniform float fresnelHueShift;
 uniform float fresnelExponent;
+uniform bool xray;
 
 const vec3 Z_AXIS = vec3(0, 0, 1);
 
@@ -48,6 +49,6 @@ void main() {
         fragColor = fresnel * vec4(fresnelColor + gradientColor, color.a);
 
         fresnel = smoothstep(0.0, 1.0, dotProduct);
-        fragColor = mix(fragColor, fresnel * color, dotProduct);
+        fragColor = mix(fragColor, color, xray ? 1.0 - dotProduct : dotProduct);
     }
 }

--- a/src/shaders/transparent/shader.ts
+++ b/src/shaders/transparent/shader.ts
@@ -16,7 +16,12 @@ export interface TransparentShaderProps {
     fresnelExponent: number;
 }
 
-export class TransparentShader extends Shader<Model> {
+interface RenderProps {
+    model: Model;
+    xray?: boolean;
+}
+
+export class TransparentShader extends Shader<RenderProps> {
     private props: TransparentShaderProps;
 
     private postProcessing: PostProcessing;
@@ -49,10 +54,11 @@ export class TransparentShader extends Shader<Model> {
         this.locations.setUniform('fresnelColor');
         this.locations.setUniform('fresnelHueShift');
         this.locations.setUniform('fresnelExponent');
+        this.locations.setUniform('xray');
     }
 
-    render(timestamp: DOMHighResTimeStamp, drawFramebuffer: WebGLFramebuffer, ...models: Model[]) {
-        super.render(timestamp, drawFramebuffer, ...models);
+    render(timestamp: DOMHighResTimeStamp, drawFramebuffer: WebGLFramebuffer, ...props: RenderProps[]) {
+        super.render(timestamp, drawFramebuffer, ...props);
 
         this.gl.uniform3fv(this.locations.getUniform('fresnelColor'), this.props.fresnelColor);
         this.gl.uniform1f(this.locations.getUniform('fresnelHueShift'), this.props.fresnelHueShift);
@@ -66,9 +72,11 @@ export class TransparentShader extends Shader<Model> {
         for (let i = 0; i < NUM_PASSES; i++) {
             this.depthPeel(i);
 
-            models?.forEach((m) => {
-                m.render(this.gl, this.locations, (f: Face) => {
-                    this.gl.uniform4fv(this.locations.getUniform('color'), [...f.material.diffuse, m.alpha]);
+            props?.forEach((p) => {
+                const model = p.model;
+                model.render(this.gl, this.locations, (f: Face) => {
+                    this.gl.uniform4fv(this.locations.getUniform('color'), [...f.material.diffuse, model.alpha]);
+                    this.gl.uniform1i(this.locations.getUniform('xray'), p?.xray ? 1 : 0);
                 });
             });
         }

--- a/src/shaders/transparent/shader.ts
+++ b/src/shaders/transparent/shader.ts
@@ -7,8 +7,6 @@ import WebGL2 from '../../gl';
 import { vec3 } from 'gl-matrix';
 import { Face } from '../../object';
 
-const NUM_PASSES = 4;
-
 export interface TransparentShaderProps {
     opaqueDepthTexture: WebGLTexture;
     fresnelColor: vec3;
@@ -30,6 +28,8 @@ export class TransparentShader extends Shader<RenderProps> {
     private depthTextures: Array<WebGLTexture>
     private colorTextures: Array<WebGLTexture>;
 
+    private static NUM_PASSES = 4;
+
     constructor(gl: WebGL2RenderingContext, props: TransparentShaderProps) {
         super(gl, vertexSrc, fragmentSrc);
 
@@ -39,7 +39,7 @@ export class TransparentShader extends Shader<RenderProps> {
 
         this.framebuffer = gl.createFramebuffer();
         this.depthTextures = WebGL2.createDepthTextures(this.gl, 2);
-        this.colorTextures = WebGL2.createColorTextures(this.gl, NUM_PASSES);
+        this.colorTextures = WebGL2.createColorTextures(this.gl, TransparentShader.NUM_PASSES);
 
         this.locations.setAttribute('vertexPosition');
         this.locations.setAttribute('normal');
@@ -48,7 +48,8 @@ export class TransparentShader extends Shader<RenderProps> {
         this.locations.setUniform('color');
         this.locations.setUniform('opaqueDepthTexture');
         this.locations.setUniform('peelDepthTexture');
-        this.locations.setUniform('shouldDepthPeel');
+        this.locations.setUniform('numPasses');
+        this.locations.setUniform('pass');
 
         // Uniforms for Fresnel effect outline.
         this.locations.setUniform('fresnelColor');
@@ -60,6 +61,8 @@ export class TransparentShader extends Shader<RenderProps> {
     render(timestamp: DOMHighResTimeStamp, drawFramebuffer: WebGLFramebuffer, ...props: RenderProps[]) {
         super.render(timestamp, drawFramebuffer, ...props);
 
+        this.gl.uniform1i(this.locations.getUniform('numPasses'), TransparentShader.NUM_PASSES);
+
         this.gl.uniform3fv(this.locations.getUniform('fresnelColor'), this.props.fresnelColor);
         this.gl.uniform1f(this.locations.getUniform('fresnelHueShift'), this.props.fresnelHueShift);
         this.gl.uniform1f(this.locations.getUniform('fresnelExponent'), this.props.fresnelExponent);
@@ -69,7 +72,7 @@ export class TransparentShader extends Shader<RenderProps> {
         this.gl.bindTexture(this.gl.TEXTURE_2D, this.props.opaqueDepthTexture);
         this.gl.uniform1i(this.locations.getUniform('opaqueDepthTexture'), 2);
 
-        for (let i = 0; i < NUM_PASSES; i++) {
+        for (let i = 0; i < TransparentShader.NUM_PASSES; i++) {
             this.depthPeel(i);
 
             props?.forEach((p) => {
@@ -89,7 +92,7 @@ export class TransparentShader extends Shader<RenderProps> {
         this.gl.enable(this.gl.BLEND);
         this.gl.blendFunc(this.gl.SRC_ALPHA, this.gl.ONE_MINUS_SRC_ALPHA);
 
-        for (let i = NUM_PASSES - 1; i >= 0; i--) {
+        for (let i = TransparentShader.NUM_PASSES - 1; i >= 0; i--) {
             this.postProcessing.render(timestamp, this.colorTextures[i]);
         }
 
@@ -105,7 +108,7 @@ export class TransparentShader extends Shader<RenderProps> {
         this.gl.uniform1i(this.locations.getUniform('peelDepthTexture'), readIndex);
 
         // No depth peeling on 0th iteration.
-        this.gl.uniform1i(this.locations.getUniform('shouldDepthPeel'), i);
+        this.gl.uniform1i(this.locations.getUniform('pass'), i);
 
         this.gl.bindFramebuffer(this.gl.DRAW_FRAMEBUFFER, this.framebuffer);
         this.gl.activeTexture(this.gl.TEXTURE0 + writeIndex);

--- a/src/shaders/transparent/vertex.glsl
+++ b/src/shaders/transparent/vertex.glsl
@@ -12,5 +12,5 @@ uniform mat4 projectionMatrix;
 void main() {
     gl_Position = projectionMatrix * modelViewMatrix * vertexPosition;
     fragDepth = gl_Position.z / gl_Position.w;
-    fragNormal = (modelViewMatrix * vec4(normal, 0)).xyz;
+    fragNormal = normalize((modelViewMatrix * vec4(normal, 0)).xyz);
 }


### PR DESCRIPTION
The brain should be very visible, but it is obscured by the head at certain viewing angles.

To fix this,
1. Render the brain to an alpha mask texture, using the `AlphaMask` shader.
2. Read the alpha mask texture in the transparency shader. The larger the alpha mask value, the more transparent the fragment will be.

Before
![before](https://github.com/tinnywang/galaxy-brain/assets/1168893/3b5f1ee5-03a7-46c9-b298-177702ee5336)

After
![alpha_mask](https://github.com/tinnywang/galaxy-brain/assets/1168893/0ef76a91-d626-449e-8178-60515eadfe12)

