### PR TITLE
Reload on window resize

### DIFF
--- a/src/controls.ts
+++ b/src/controls.ts
@@ -1,3 +1,4 @@
+import $ from "jquery";
 import { glMatrix, vec3 } from "gl-matrix";
 import Matrix from "./matrix";
 import GalaxyBrain from "./galaxy_brain";
@@ -77,6 +78,10 @@ const Controls = (
 
     galaxyBrain.evolve(stage);
     canvas.attr("class", `stage-${stage}`);
+  });
+
+  $(window).on("resize", () => {
+    window.location.reload();
   });
 };
 


### PR DESCRIPTION
When the window is resized, the canvas's dimensions are not updated. This causes the scene to look distorted.

The correct way of fixing this is to have the window's resize handler
1. update the canvas's width and height
2. recreate all render textures to use the canvas's new dimensions

This will take a considerable amount of refactoring, so I've opted for the quick and dirty approach of reloading the page when the window is resized.
