### PR TITLE
Mobile fixes

### DIFF
--- a/src/style.css
+++ b/src/style.css
@@ -79,6 +79,8 @@ input[type="range"]::-moz-range-track {
 input[type="range"]::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
+  border: none;
+  background: transparent;
   background-image: url("./assets/brain.png");
   background-size: 30px;
   width: 30px;


### PR DESCRIPTION
- Set the slider thumb background to `transparent`. It is apparently non-transparent in Chrome for iPhone . I can't actually verify that this PR fixes the issue without bothering people, but I have seen a similar issue with Firefox on desktop and have applied the same fix.
- Handle touch events alongside mouse events.