### PR TITLE
Bug fixes

### DIFF
--- a/src/animations/rotation.ts
+++ b/src/animations/rotation.ts
@@ -24,15 +24,20 @@ export class Rotation extends Animation {
 
         if (!this.isDone()) {
             let delta = this.elapsedTimestamp ? this.delta * this.elapsedTimestamp : 0;
+            if (Math.abs(this.angle) < Math.abs(delta)) {
+              delta = this.angle;
+            }
+
             this.matrices.forEach((m) => {
                 const rotation = mat4.fromRotation(mat4.create(), delta, this.axis);
                 mat4.multiply(m, rotation, m);
             });
+
             this.angle -= delta;
         }
     }
 
     isDone(): boolean {
-        return this.delta > 0 ? this.angle <= 0 : this.angle >= 0;
+        return this.delta === 0;
     }
 }

--- a/src/animations/scale.ts
+++ b/src/animations/scale.ts
@@ -31,18 +31,23 @@ export class Scale extends Animation {
         // Scale the model linearly over time.
         // If the model were scaled by delta every frame, it would be scaled exponentially (delta^n).
         if (!this.isDone()) {
-           let delta = this.elapsedTimestamp ? this.delta * this.elapsedTimestamp : 0;
+            let delta = this.elapsedTimestamp ? this.delta * this.elapsedTimestamp : 0;
             if (!this.scaleUp) {
-                delta *= -1
+                delta *= -1;
             }
-            const s = 1 + delta / this.scaling();
+
+            const scaling = this.scaling();
+            if ((this.scaleUp && this.scale < scaling + delta) || (!this.scaleUp && this.scale > scaling + delta)) {
+                delta = this.scale - scaling;
+            }
+
+            const s = 1 + delta / scaling;
             mat4.scale(this.matrix, this.matrix, vec3.fromValues(s, s, s));
         }
     }
 
     isDone() {
-        const s = this.scaling();
-        return this.scaleUp ? s >= this.scale : s <= this.scale;
+        return this.scale === this.scaling();
     }
 
     private scaling() {

--- a/src/index.html
+++ b/src/index.html
@@ -3,6 +3,7 @@
   <head>
     <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Share+Tech+Mono">
     <meta charset="utf-8">
+    <title>Galaxy Brain</title>
   </head>
   <body>
     <div class="controls">

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -14,8 +14,7 @@ module.exports = {
   plugins: [
     new HtmlWebpackPlugin({
       favicon: "./src/assets/brain.png",
-      template: "./src/index.html",
-      title: "Galaxy Brain"
+      template: "./src/index.html"
     }),
   ],
   module: {


### PR DESCRIPTION
- Fix the page title. The `title` [option](https://github.com/jantimon/html-webpack-plugin#options) for `html-webpack-plugin` only applies to generated HTML pages, not templates.
- Fix under/over-rotations in the rotation animation. 
- Fix under/over-scaling in the scale animation.

The last two issues were most apparent with low frame rates because the deltas between frames were larger.